### PR TITLE
Add missing secret

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,6 +89,8 @@ jobs:
           context: .
           load: true
           file: ./Dockerfile
+          secrets: |
+            github=${{ secrets.GITHUB_TOKEN }}          
           tags: |
             ${{ needs.preconditions.outputs.repo_name }}:latest
           labels: |

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@digicatapult/dscp-node": "latest",
+        "@digicatapult/dscp-node": "^3.0.1",
         "body-parser": "^1.19.0",
         "compression": "^1.7.4",
         "cors": "^2.8.5",


### PR DESCRIPTION
The release build failed because I missed a secret to add in the `release` workflow

https://github.com/digicatapult/dscp-identity-service/runs/6076978363?check_suite_focus=true
