### PR TITLE
IN-249 bug where listing members with aliases fails

### DIFF
--- a/app/util/appUtil.js
+++ b/app/util/appUtil.js
@@ -40,7 +40,7 @@ async function membershipReducer(members) {
   return members.reduce((acc, item) => {
     const memberAlias = memberAliases.find(({ address }) => address === item) || null
 
-    acc.push({ address: item, alias: memberAlias ? memberAlias[0].alias : memberAlias })
+    acc.push({ address: item, alias: memberAlias ? memberAlias.alias : memberAlias })
 
     return acc
   }, [])

--- a/helm/dscp-identity-service/Chart.yaml
+++ b/helm/dscp-identity-service/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: dscp-identity-service
-appVersion: '1.0.1'
+appVersion: '1.0.2'
 description: A Helm chart for dscp-identity-service
-version: '1.0.1'
+version: '1.0.2'
 type: application
 maintainers:
   - name: digicatapult

--- a/helm/dscp-identity-service/values.yaml
+++ b/helm/dscp-identity-service/values.yaml
@@ -21,7 +21,7 @@ replicaCount: 1
 image:
   repository: ghcr.io/digicatapult/dscp-identity-service
   pullPolicy: IfNotPresent
-  tag: 'v1.0.1'
+  tag: 'v1.0.2'
   pullSecrets: ['ghcr-digicatapult']
 
 postgresql:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/dscp-identity-service",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/dscp-identity-service",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@digicatapult/dscp-node": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/dscp-identity-service",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Identity Service for DSCP",
   "main": "app/index.js",
   "scripts": {


### PR DESCRIPTION
Fix the bug where listing a member with an alias fails. This is due to a broken reducer

See https://github.com/digicatapult/dscp-identity-service/runs/6354141761?check_suite_focus=true for failing case

Note this also adds an afterEach to decouple the tests from each other