### PR TITLE
IN-229: new route /self.

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ npx knex migrate:latest --env test
 | DB_NAME           |    N     | `dscp`  | Name of the database to connect to                                                                                   |
 | DB_USERNAME       |    Y     |    -    | Username to connect to the database with                                                                             |
 | DB_PASSWORD       |    Y     |    -    | Password to connect to the database with                                                                             |
+| SELF_ADDRESS      |    N     |    -    | Instance wallet address that is returned by `/self` endpoint                                                         |
 
 ## Running the API
 

--- a/app/api-v1/routes/self.js
+++ b/app/api-v1/routes/self.js
@@ -1,14 +1,11 @@
-const logger = require('../../logger')
 const { selfResponses, validateSelfResponse } = require('../validators/selfResponseValidator')
 const { SELF_ADDRESS } = require('../../env')
 
-module.exports = function (apiService) {
+module.exports = function () {
   const doc = {
-  
     GET: async function (req, res) {
-      if (validateSelfResponse(400, SELF_ADDRESS)) {
-        return res.status(400).json(validationErrors)
-      }
+      const errors = validateSelfResponse(400, SELF_ADDRESS, res)
+      if (errors) return res.status(400).send(errors)
       res.status(200).send(SELF_ADDRESS)
     },
   }

--- a/app/api-v1/routes/self.js
+++ b/app/api-v1/routes/self.js
@@ -4,6 +4,7 @@ const { SELF_ADDRESS } = require('../../env')
 
 module.exports = function (apiService) {
   const doc = {
+  
     GET: async function (req, res) {
       if (validateSelfResponse(400, SELF_ADDRESS)) {
         return res.status(400).json(validationErrors)
@@ -16,7 +17,7 @@ module.exports = function (apiService) {
     summary: 'Get self address',
     responses: selfResponses,
     security: [{ bearerAuth: [] }],
-    tags: ['address'],
+    tags: ['members'],
   }
 
   return doc

--- a/app/api-v1/routes/self.js
+++ b/app/api-v1/routes/self.js
@@ -1,0 +1,23 @@
+const logger = require('../../logger')
+const { selfResponses, validateSelfResponse } = require('../validators/selfResponseValidator')
+const { SELF_ADDRESS } = require('../../env')
+
+module.exports = function (apiService) {
+  const doc = {
+    GET: async function (req, res) {
+      if (validateSelfResponse(400, SELF_ADDRESS)) {
+        return res.status(400).json(validationErrors)
+      }
+      res.status(200).send(SELF_ADDRESS)
+    },
+  }
+
+  doc.GET.apiDoc = {
+    summary: 'Get self address',
+    responses: selfResponses,
+    security: [{ bearerAuth: [] }],
+    tags: ['address'],
+  }
+
+  return doc
+}

--- a/app/api-v1/validators/selfResponseValidator.js
+++ b/app/api-v1/validators/selfResponseValidator.js
@@ -1,0 +1,29 @@
+const OpenAPIResponseValidator = require('openapi-response-validator').default
+
+const apiDocResponses = require('../api-doc-responses')
+const apiDoc = require('../api-doc')
+
+const selfResponses = {
+  200: {
+    description: 'Return self address',
+    content: {
+      content: {
+        'application/json': {
+          schema: apiDoc.components.schemas.Address,
+        },
+      },
+    },
+  },
+  400: apiDocResponses['400'],
+  default: apiDocResponses.default,
+}
+
+const validateSelfResponse = (statusCode, result) => {
+  const responseValidator = new OpenAPIResponseValidator({ responses: selfResponses, components: apiDoc.components })
+
+  return responseValidator.validateResponse(statusCode, result)
+}
+module.exports = {
+  selfResponses,
+  validateSelfResponse,
+}

--- a/app/api-v1/validators/selfResponseValidator.js
+++ b/app/api-v1/validators/selfResponseValidator.js
@@ -3,19 +3,17 @@ const OpenAPIResponseValidator = require('openapi-response-validator').default
 const apiDocResponses = require('../api-doc-responses')
 const apiDoc = require('../api-doc')
 
+
 const selfResponses = {
   200: {
-    description: 'Return self address',
+    description: 'Get member address from alias',
     content: {
-      content: {
-        'application/json': {
-          schema: apiDoc.components.schemas.Address,
-        },
+      'application/json': {
+        schema: apiDoc.components.schemas.Address,
       },
     },
   },
-  400: apiDocResponses['400'],
-  default: apiDocResponses.default,
+  ...apiDocResponses,
 }
 
 const validateSelfResponse = (statusCode, result) => {

--- a/app/api-v1/validators/selfResponseValidator.js
+++ b/app/api-v1/validators/selfResponseValidator.js
@@ -1,8 +1,6 @@
 const OpenAPIResponseValidator = require('openapi-response-validator').default
-
 const apiDocResponses = require('../api-doc-responses')
 const apiDoc = require('../api-doc')
-
 
 const selfResponses = {
   200: {

--- a/app/env.js
+++ b/app/env.js
@@ -12,6 +12,7 @@ if (process.env.NODE_ENV === 'test') {
 const vars = envalid.cleanEnv(
   process.env,
   {
+    SELF_ADDRESS: envalid.str({ devDefault: '5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty' }),
     SERVICE_TYPE: envalid.str({ default: 'dscp-identity-service'.toUpperCase().replace(/-/g, '_') }),
     PORT: envalid.port({ default: 3002 }),
     API_HOST: envalid.host({ devDefault: 'localhost' }),

--- a/helm/dscp-identity-service/Chart.yaml
+++ b/helm/dscp-identity-service/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: dscp-identity-service
-appVersion: '1.1.1'
+appVersion: '1.2.0'
 description: A Helm chart for dscp-identity-service
-version: '1.1.1'
+version: '1.2.0'
 type: application
 maintainers:
   - name: digicatapult

--- a/helm/dscp-identity-service/Chart.yaml
+++ b/helm/dscp-identity-service/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: dscp-identity-service
-appVersion: '1.1.0'
+appVersion: '1.1.1'
 description: A Helm chart for dscp-identity-service
-version: '1.1.0'
+version: '1.1.1'
 type: application
 maintainers:
   - name: digicatapult

--- a/helm/dscp-identity-service/templates/configmap.yaml
+++ b/helm/dscp-identity-service/templates/configmap.yaml
@@ -15,3 +15,4 @@ data:
   authAudience: {{ .Values.config.auth.audience | quote }}
   authIssuer: {{ .Values.config.auth.issuer | quote }}
   authTokenUrl: {{ .Values.config.auth.tokenUrl | quote }}
+  selfAddress: {{ .Values.config.selfAddress }}

--- a/helm/dscp-identity-service/templates/deployment.yaml
+++ b/helm/dscp-identity-service/templates/deployment.yaml
@@ -24,11 +24,6 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
           command: [ 'npx', 'knex', "migrate:latest", "--env", "production" ]
           env:
-            - name: SELF_ADDRESS
-              valueFrom:
-                configMapKeyRef:
-                  name: {{ include "dscp-identity-service.fullname" . }}-config
-                  key: selfAddress
             - name: DB_HOST
               valueFrom:
                 configMapKeyRef:
@@ -59,6 +54,11 @@ spec:
           image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
           imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
           env:
+            - name: SELF_ADDRESS
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "dscp-identity-service.fullname" . }}-config
+                  key: selfAddress
             - name: PORT
               valueFrom:
                 configMapKeyRef:

--- a/helm/dscp-identity-service/templates/deployment.yaml
+++ b/helm/dscp-identity-service/templates/deployment.yaml
@@ -24,6 +24,11 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
           command: [ 'npx', 'knex', "migrate:latest", "--env", "production" ]
           env:
+            - name: SELF_ADDRESS
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "dscp-identity-service.fullname" . }}-config
+                  key: selfAddress
             - name: DB_HOST
               valueFrom:
                 configMapKeyRef:

--- a/helm/dscp-identity-service/values.yaml
+++ b/helm/dscp-identity-service/values.yaml
@@ -5,6 +5,7 @@ config:
   dbName: dscp
   dbPort: 5432
   enableLivenessProbe: true
+  selfAddress: YYrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY
   auth:
     jwksUri: https://dscp.eu.auth0.com/.well-known/jwks.json
     audience: dscp-test

--- a/helm/dscp-identity-service/values.yaml
+++ b/helm/dscp-identity-service/values.yaml
@@ -5,7 +5,7 @@ config:
   dbName: dscp
   dbPort: 5432
   enableLivenessProbe: true
-  selfAddress: YYrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY
+  selfAddress: 5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty # dev wallet address
   auth:
     jwksUri: https://dscp.eu.auth0.com/.well-known/jwks.json
     audience: dscp-test

--- a/helm/dscp-identity-service/values.yaml
+++ b/helm/dscp-identity-service/values.yaml
@@ -5,7 +5,8 @@ config:
   dbName: dscp
   dbPort: 5432
   enableLivenessProbe: true
-  selfAddress: 5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty # dev wallet address
+  # dev wallet address
+  selfAddress: 5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty
   auth:
     jwksUri: https://dscp.eu.auth0.com/.well-known/jwks.json
     audience: dscp-test

--- a/helm/dscp-identity-service/values.yaml
+++ b/helm/dscp-identity-service/values.yaml
@@ -21,7 +21,7 @@ replicaCount: 1
 image:
   repository: ghcr.io/digicatapult/dscp-identity-service
   pullPolicy: IfNotPresent
-  tag: 'v1.1.0'
+  tag: 'v1.1.1'
   pullSecrets: ['ghcr-digicatapult']
 
 postgresql:

--- a/helm/dscp-identity-service/values.yaml
+++ b/helm/dscp-identity-service/values.yaml
@@ -23,7 +23,7 @@ replicaCount: 1
 image:
   repository: ghcr.io/digicatapult/dscp-identity-service
   pullPolicy: IfNotPresent
-  tag: 'v1.1.1'
+  tag: 'v1.2.0'
   pullSecrets: ['ghcr-digicatapult']
 
 postgresql:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/dscp-identity-service",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/dscp-identity-service",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/dscp-identity-service",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "Identity Service for DSCP",
   "main": "app/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/dscp-identity-service",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Identity Service for DSCP",
   "main": "app/index.js",
   "scripts": {

--- a/test/helper/routeHelper.js
+++ b/test/helper/routeHelper.js
@@ -77,10 +77,26 @@ async function putMemberAliasRoute({ app }, authToken, address, { alias }) {
     })
 }
 
+async function getSelfAddress({ app }, authToken) {
+  return request(app)
+    .get(`/${API_MAJOR_VERSION}/self`)
+    .set('Accept', 'application/json')
+    .set('Content-Type', 'application/json')
+    .set('Authorization', `Bearer ${authToken}`)
+    .then((response) => {
+      return response
+    })
+    .catch((err) => {
+      console.error(`getSelfAddressError: ${err}`)
+      return err
+    })
+}
+
 module.exports = {
   apiDocs,
   healthCheck,
   getMembersRoute,
+  getSelfAddress,
   getMemberByAliasOrAddressRoute,
   putMemberAliasRoute,
 }

--- a/test/integration/routes.test.js
+++ b/test/integration/routes.test.js
@@ -4,7 +4,12 @@ const { expect } = require('chai')
 const nock = require('nock')
 
 const { createHttpServer } = require('../../app/server')
-const { getMembersRoute, getMemberByAliasOrAddressRoute, putMemberAliasRoute } = require('../helper/routeHelper')
+const {
+  getMembersRoute,
+  getMemberByAliasOrAddressRoute,
+  putMemberAliasRoute,
+  getSelfAddress
+} = require('../helper/routeHelper')
 const USER_ALICE_TOKEN = '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY'
 const ALICE_STASH = '5GNJqTPyNqANBkUVMN1LPPrxXnFouWXoe2wNSmmEoLctxiZY'
 const USER_BOB_TOKEN = '5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty'
@@ -13,6 +18,7 @@ const { AUTH_ISSUER, AUTH_AUDIENCE } = require('../../app/env')
 const { cleanup } = require('../seeds/members')
 
 describe('routes', function () {
+  this.timeout(3000)
   before(async () => {
     nock.disableNetConnect()
     nock.enableNetConnect((host) => host.includes('127.0.0.1') || host.includes('localhost'))
@@ -167,6 +173,13 @@ describe('routes', function () {
 
       expect(res.status).to.equal(200)
       expect(res.body).deep.equal(expectedResult)
+    })
+
+    test('get self address or returmn default', async function() {
+      const { status, text } = await getSelfAddress(app,authToken)
+
+      expect(status).to.equal(200)
+      expect(text).to.equal('5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty')
     })
   })
 })

--- a/test/integration/routes.test.js
+++ b/test/integration/routes.test.js
@@ -8,7 +8,7 @@ const {
   getMembersRoute,
   getMemberByAliasOrAddressRoute,
   putMemberAliasRoute,
-  getSelfAddress
+  getSelfAddress,
 } = require('../helper/routeHelper')
 const USER_ALICE_TOKEN = '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY'
 const ALICE_STASH = '5GNJqTPyNqANBkUVMN1LPPrxXnFouWXoe2wNSmmEoLctxiZY'
@@ -175,9 +175,8 @@ describe('routes', function () {
       expect(res.body).deep.equal(expectedResult)
     })
 
-    test('get self address or returmn default', async function() {
-      const { status, text } = await getSelfAddress(app,authToken)
-
+    test('get self address or returmn default', async function () {
+      const { status, text } = await getSelfAddress(app, authToken)
       expect(status).to.equal(200)
       expect(text).to.equal('5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty')
     })


### PR DESCRIPTION
### What

Adding a new route `/self` for retrieving `SELF_ADDRESS` env variable or `devDefault`

#### Changes
- api-doc update including route and request validator
- integration test along with other routes

```
  routes
    authenticated routes
      ✔ return membership members
      ✔ return membership members with aliases
      ✔ update non-existing member alias
      ✔ update existing member alias
      ✔ update existing member alias
      ✔ update alternative non-existing member with duplicate alias
      ✔ get member by alias
      ✔ get member by incorrect alias
      ✔ get member by invalid alias
      ✔ get member by address
      ✔ get self address or return default <--- THIS ONE
```