### PR TITLE
Add AUTH_TYPE env

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -153,6 +153,9 @@ jobs:
       - name: Dependency Check
         run: npm run depcheck
   tests:
+    strategy:
+      matrix:
+        auth: [NONE, JWT]
     name: Run tests
     runs-on: ubuntu-latest
     needs: [preconditions]
@@ -185,6 +188,9 @@ jobs:
         run: npx knex migrate:latest --env test
       - name: Run tests
         run: npm run test
+        env:
+          AUTH_TYPE: ${{ matrix.auth }}
+
   check-version:
     name: 'Check version'
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -146,6 +146,9 @@ jobs:
         run: npm run depcheck
 
   tests:
+    strategy:
+      matrix:
+        auth: [NONE, JWT]
     name: Run tests
     runs-on: ubuntu-latest
     steps:
@@ -177,6 +180,8 @@ jobs:
         run: npx knex migrate:latest --env test
       - name: Run tests
         run: npm run test
+        env:
+          AUTH_TYPE: ${{ matrix.auth }}
 
   check-version:
     name: 'Check version'

--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,6 @@ coverage
 .idea
 .env
 .vscode
+coverage.json
 
 helm/**/*.tgz

--- a/README.md
+++ b/README.md
@@ -39,27 +39,33 @@ npx knex migrate:latest --env test
 
 `dscp-identity-service` is configured primarily using environment variables as follows:
 
-| variable          | required | default | description                                                                                                          |
-| :---------------- | :------: | :-----: | :------------------------------------------------------------------------------------------------------------------- |
-| SERVICE_TYPE      |    N     | `info`  | Logging level. Valid values are [`trace`, `debug`, `info`, `warn`, `error`, `fatal`]                                 |
-| PORT              |    N     | `3001`  | The port for the API to listen on                                                                                    |
-| LOG_LEVEL         |    N     | `info`  | Logging level. Valid values are [`trace`, `debug`, `info`, `warn`, `error`, `fatal`]                                 |
-| API_VERSION       |    N     |    -    | API version                                                                                                          |
-| API_MAJOR_VERSION |    N     |    -    | API major version                                                                                                    |
-| API_HOST          |    Y     |    -    | The hostname of the `dscp-node` the API should connect to                                                            |
-| API_PORT          |    N     | `9944`  | The port of the `dscp-node` the API should connect to                                                                |
-| LOG_LEVEL         |    N     | `info`  | Logging level. Valid values are [`trace`, `debug`, `info`, `warn`, `error`, `fatal`]                                 |
-| USER_URI          |    Y     |    -    | The Substrate `URI` representing the private key to use when making `dscp-node` transactions                         |
-| AUTH_JWKS_URI     |    Y     |    -    | JSON Web Key Set containing public keys used by the Auth0 API e.g. `https://test.eu.auth0.com/.well-known/jwks.json` |
-| AUTH_AUDIENCE     |    Y     |    -    | Identifier of the Auth0 API                                                                                          |
-| AUTH_ISSUER       |    Y     |    -    | Domain of the Auth0 API e.g. `https://test.eu.auth0.com/`                                                            |
-| AUTH_TOKEN_URL    |    Y     |    -    | Auth0 API endpoint that issues an Authorisation (Bearer) access token e.g. `https://test.auth0.com/oauth/token`      |
-| DB_HOST           |    Y     |    -    | Hostname for the db                                                                                                  |
-| DB_PORT           |    N     |  5432   | Port to connect to the db                                                                                            |
-| DB_NAME           |    N     | `dscp`  | Name of the database to connect to                                                                                   |
-| DB_USERNAME       |    Y     |    -    | Username to connect to the database with                                                                             |
-| DB_PASSWORD       |    Y     |    -    | Password to connect to the database with                                                                             |
-| SELF_ADDRESS      |    N     |    -    | Instance wallet address that is returned by `/self` endpoint                                                         |
+| variable          | required | default | description                                                                                  |
+| :---------------- | :------: | :-----: | :------------------------------------------------------------------------------------------- |
+| SERVICE_TYPE      |    N     | `info`  | Logging level. Valid values are [`trace`, `debug`, `info`, `warn`, `error`, `fatal`]         |
+| PORT              |    N     | `3001`  | The port for the API to listen on                                                            |
+| LOG_LEVEL         |    N     | `info`  | Logging level. Valid values are [`trace`, `debug`, `info`, `warn`, `error`, `fatal`]         |
+| API_VERSION       |    N     |    -    | API version                                                                                  |
+| API_MAJOR_VERSION |    N     |    -    | API major version                                                                            |
+| API_HOST          |    Y     |    -    | The hostname of the `dscp-node` the API should connect to                                    |
+| API_PORT          |    N     | `9944`  | The port of the `dscp-node` the API should connect to                                        |
+| LOG_LEVEL         |    N     | `info`  | Logging level. Valid values are [`trace`, `debug`, `info`, `warn`, `error`, `fatal`]         |
+| USER_URI          |    Y     |    -    | The Substrate `URI` representing the private key to use when making `dscp-node` transactions |
+| DB_HOST           |    Y     |    -    | Hostname for the db                                                                          |
+| DB_PORT           |    N     |  5432   | Port to connect to the db                                                                    |
+| DB_NAME           |    N     | `dscp`  | Name of the database to connect to                                                           |
+| DB_USERNAME       |    Y     |    -    | Username to connect to the database with                                                     |
+| DB_PASSWORD       |    Y     |    -    | Password to connect to the database with                                                     |
+| SELF_ADDRESS      |    N     |    -    | Instance wallet address that is returned by `/self` endpoint                                 |
+| AUTH_TYPE         |    N     | `NONE`  | Authentication type for routes on the service. Valid values: [`NONE`, `JWT`]                 |
+
+The following environment variables are additionally used when `AUTH_TYPE : 'JWT'`
+
+| variable       | required |                       default                       | description                                                           |
+| :------------- | :------: | :-------------------------------------------------: | :-------------------------------------------------------------------- |
+| AUTH_JWKS_URI  |    N     | `https://inteli.eu.auth0.com/.well-known/jwks.json` | JSON Web Key Set containing public keys used by the Auth0 API         |
+| AUTH_AUDIENCE  |    N     |                    `inteli-dev`                     | Identifier of the Auth0 API                                           |
+| AUTH_ISSUER    |    N     |           `https://inteli.eu.auth0.com/`            | Domain of the Auth0 API `                                             |
+| AUTH_TOKEN_URL |    N     |      `https://inteli.eu.auth0.com/oauth/token`      | Auth0 API endpoint that issues an Authorisation (Bearer) access token |
 
 ## Running the API
 
@@ -73,7 +79,7 @@ npm start
 
 ### Authenticated endpoints
 
-The rest of the endpoints in `dscp-api` require authentication in the form of a header `'Authorization: Bearer YOUR_ACCESS_TOKEN'`:
+If `AUTH_TYPE` env is set to `JWT`, the rest of the endpoints in `dscp-identity-service` require authentication in the form of a header `'Authorization: Bearer YOUR_ACCESS_TOKEN'`:
 
 1. [GET /members/](#GET-/members)
 2. [GET /members/:address](#PUT-/members/:address)

--- a/app/api-v1/routes/members.js
+++ b/app/api-v1/routes/members.js
@@ -1,5 +1,6 @@
 const logger = require('../../logger')
 const { membershipReducer } = require('../../util/appUtil')
+const { getDefaultSecurity } = require('../../util/authUtil')
 const { membersResponses, validateMembersResponse } = require('../validators/membersResponseValidator')
 
 module.exports = function (apiService) {
@@ -31,7 +32,7 @@ module.exports = function (apiService) {
   doc.GET.apiDoc = {
     summary: 'Get members',
     responses: membersResponses,
-    security: [{ bearerAuth: [] }],
+    security: getDefaultSecurity(),
     tags: ['members'],
   }
 

--- a/app/api-v1/routes/members/{address}.js
+++ b/app/api-v1/routes/members/{address}.js
@@ -2,6 +2,7 @@ const {
   memberAliasesResponses,
   validateMemberAliasesResponse,
 } = require('../../validators/memberAliasesResponseValidator')
+const { getDefaultSecurity } = require('../../../util/authUtil')
 
 module.exports = function (apiService) {
   const doc = {
@@ -49,7 +50,7 @@ module.exports = function (apiService) {
       },
     },
     responses: memberAliasesResponses,
-    security: [{ bearerAuth: [] }],
+    security: getDefaultSecurity(),
     tags: ['members'],
   }
 

--- a/app/api-v1/routes/members/{aliasOrAddress}.js
+++ b/app/api-v1/routes/members/{aliasOrAddress}.js
@@ -3,6 +3,7 @@ const {
   validateMemberAddressResponse,
 } = require('../../validators/memberAddressResponseValidator')
 const apiDoc = require('../../api-doc')
+const { getDefaultSecurity } = require('../../../util/authUtil')
 
 const addrRegex = new RegExp(apiDoc.components.schemas.Address.pattern)
 const aliasRegex = new RegExp(apiDoc.components.schemas.Alias.pattern)
@@ -50,7 +51,7 @@ module.exports = function (apiService) {
       },
     ],
     responses: memberAddressResponses,
-    security: [{ bearerAuth: [] }],
+    security: getDefaultSecurity(),
     tags: ['members'],
   }
 

--- a/app/api-v1/routes/self.js
+++ b/app/api-v1/routes/self.js
@@ -1,5 +1,6 @@
 const { selfResponses, validateSelfResponse } = require('../validators/selfResponseValidator')
 const { SELF_ADDRESS } = require('../../env')
+const { getDefaultSecurity } = require('../../util/authUtil')
 
 module.exports = function () {
   const doc = {
@@ -13,7 +14,7 @@ module.exports = function () {
   doc.GET.apiDoc = {
     summary: 'Get self address',
     responses: selfResponses,
-    security: [{ bearerAuth: [] }],
+    security: getDefaultSecurity(),
     tags: ['members'],
   }
 

--- a/app/env.js
+++ b/app/env.js
@@ -9,9 +9,24 @@ if (process.env.NODE_ENV === 'test') {
   dotenv.config({ path: '.env' })
 }
 
+const AUTH_ENVS = {
+  NONE: {},
+  JWT: {
+    AUTH_JWKS_URI: envalid.url({ devDefault: 'https://inteli.eu.auth0.com/.well-known/jwks.json' }),
+    AUTH_AUDIENCE: envalid.str({ devDefault: 'inteli-dev' }),
+    AUTH_ISSUER: envalid.url({ devDefault: 'https://inteli.eu.auth0.com/' }),
+    AUTH_TOKEN_URL: envalid.url({ devDefault: 'https://inteli.eu.auth0.com/oauth/token' }),
+  },
+}
+
+const { AUTH_TYPE } = envalid.cleanEnv(process.env, {
+  AUTH_TYPE: envalid.str({ default: 'NONE', choices: ['NONE', 'JWT'] }),
+})
+
 const vars = envalid.cleanEnv(
   process.env,
   {
+    ...AUTH_ENVS[AUTH_TYPE],
     SELF_ADDRESS: envalid.str({ devDefault: '5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty' }),
     SERVICE_TYPE: envalid.str({ default: 'dscp-identity-service'.toUpperCase().replace(/-/g, '_') }),
     PORT: envalid.port({ default: 3002 }),
@@ -19,10 +34,6 @@ const vars = envalid.cleanEnv(
     API_PORT: envalid.port({ default: 9944 }),
     API_VERSION: envalid.str({ default: version }),
     API_MAJOR_VERSION: envalid.str({ default: 'v1' }),
-    AUTH_JWKS_URI: envalid.url({ devDefault: 'https://inteli.eu.auth0.com/.well-known/jwks.json' }),
-    AUTH_AUDIENCE: envalid.str({ devDefault: 'inteli-dev' }),
-    AUTH_ISSUER: envalid.url({ devDefault: 'https://inteli.eu.auth0.com/' }),
-    AUTH_TOKEN_URL: envalid.url({ devDefault: 'https://inteli.eu.auth0.com/oauth/token' }),
     METADATA_KEY_LENGTH: envalid.num({ default: 32 }),
     METADATA_VALUE_LITERAL_LENGTH: envalid.num({ default: 32 }),
     PROCESS_IDENTIFIER_LENGTH: envalid.num({ default: 32 }),
@@ -38,4 +49,7 @@ const vars = envalid.cleanEnv(
   }
 )
 
-module.exports = vars
+module.exports = {
+  ...vars,
+  AUTH_TYPE,
+}

--- a/app/server.js
+++ b/app/server.js
@@ -7,7 +7,7 @@ const path = require('path')
 const bodyParser = require('body-parser')
 const compression = require('compression')
 
-const { PORT, API_VERSION, API_MAJOR_VERSION } = require('./env')
+const { PORT, API_VERSION, API_MAJOR_VERSION, AUTH_TYPE } = require('./env')
 const logger = require('./logger')
 const v1ApiDoc = require('./api-v1/api-doc')
 const v1ApiService = require('./api-v1/services/apiService')
@@ -31,14 +31,19 @@ async function createHttpServer() {
     next()
   })
 
+  const securityHandlers =
+    AUTH_TYPE === 'JWT'
+      ? {
+          bearerAuth: (req) => {
+            return verifyJwks(req.headers['authorization'])
+          },
+        }
+      : {}
+
   initialize({
     app,
     apiDoc: v1ApiDoc,
-    securityHandlers: {
-      bearerAuth: (req) => {
-        return verifyJwks(req.headers['authorization'])
-      },
-    },
+    securityHandlers: securityHandlers,
     dependencies: {
       apiService: v1ApiService,
     },

--- a/app/util/authUtil.js
+++ b/app/util/authUtil.js
@@ -1,7 +1,7 @@
 const jwksRsa = require('jwks-rsa')
 const jwt = require('jsonwebtoken')
 
-const { AUTH_AUDIENCE, AUTH_JWKS_URI, AUTH_ISSUER } = require('../env')
+const { AUTH_AUDIENCE, AUTH_JWKS_URI, AUTH_ISSUER, AUTH_TYPE } = require('../env')
 const logger = require('../logger')
 
 const client = jwksRsa({
@@ -47,6 +47,18 @@ const verifyJwks = async (authHeader) => {
   })
 }
 
+const getDefaultSecurity = () => {
+  switch (AUTH_TYPE) {
+    case 'NONE':
+      return []
+    case 'JWT':
+      return [{ bearerAuth: [] }]
+    default:
+      return []
+  }
+}
+
 module.exports = {
   verifyJwks,
+  getDefaultSecurity,
 }

--- a/helm/dscp-identity-service/Chart.yaml
+++ b/helm/dscp-identity-service/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: dscp-identity-service
-appVersion: '1.2.3'
+appVersion: '1.3.0'
 description: A Helm chart for dscp-identity-service
-version: '1.2.3'
+version: '1.3.0'
 type: application
 maintainers:
   - name: digicatapult

--- a/helm/dscp-identity-service/templates/configmap.yaml
+++ b/helm/dscp-identity-service/templates/configmap.yaml
@@ -11,8 +11,11 @@ data:
   dbHost: {{ include "dscp-identity-service.postgresql.fullname" . }}
   dbPort: {{ .Values.config.dbPort | quote }}
   dbName: {{ .Values.config.dbName }}
+  {{- if eq .Values.config.auth.type "JWT" }}
   authJwksUri: {{ .Values.config.auth.jwksUri | quote }}
   authAudience: {{ .Values.config.auth.audience | quote }}
   authIssuer: {{ .Values.config.auth.issuer | quote }}
   authTokenUrl: {{ .Values.config.auth.tokenUrl | quote }}
+  {{- end }}
   selfAddress: {{ .Values.config.selfAddress }}
+  authType: {{ .Values.config.auth.type }}

--- a/helm/dscp-identity-service/templates/deployment.yaml
+++ b/helm/dscp-identity-service/templates/deployment.yaml
@@ -76,6 +76,7 @@ spec:
                   key: nodeHost
             - name: API_PORT
               value: "9944"
+            {{- if eq .Values.config.auth.type "JWT" }}
             - name: AUTH_JWKS_URI
               valueFrom:
                 configMapKeyRef:
@@ -96,6 +97,7 @@ spec:
                 configMapKeyRef:
                   name: {{ include "dscp-identity-service.fullname" . }}-config
                   key: authTokenUrl
+            {{- end }}
             - name: DB_HOST
               valueFrom:
                 configMapKeyRef:
@@ -121,6 +123,11 @@ spec:
                 secretKeyRef:
                   name: {{ include "dscp-identity-service.fullname" . }}-secret
                   key: dbPassword
+            - name: AUTH_TYPE
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "dscp-identity-service.fullname" . }}-config
+                  key: authType
           ports:
             - containerPort: {{ .Values.config.port }}
               name: http

--- a/helm/dscp-identity-service/values.yaml
+++ b/helm/dscp-identity-service/values.yaml
@@ -8,6 +8,7 @@ config:
   # dev wallet address
   selfAddress: 5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty
   auth:
+    type: NONE
     jwksUri: https://dscp.eu.auth0.com/.well-known/jwks.json
     audience: dscp-test
     issuer: https://dscp.eu.auth0.com/

--- a/helm/dscp-identity-service/values.yaml
+++ b/helm/dscp-identity-service/values.yaml
@@ -24,7 +24,7 @@ replicaCount: 1
 image:
   repository: ghcr.io/digicatapult/dscp-identity-service
   pullPolicy: IfNotPresent
-  tag: 'v1.2.3'
+  tag: 'v1.3.0'
   pullSecrets: ['ghcr-digicatapult']
 
 postgresql:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/dscp-identity-service",
-  "version": "1.2.3",
+  "version": "1.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/dscp-identity-service",
-      "version": "1.2.3",
+      "version": "1.3.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@digicatapult/dscp-node": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -1,15 +1,17 @@
 {
   "name": "@digicatapult/dscp-identity-service",
-  "version": "1.2.3",
+  "version": "1.3.0",
   "description": "Identity Service for DSCP",
   "main": "app/index.js",
   "scripts": {
     "test": "NODE_ENV=test mocha --config ./test/mocharc.js ./test",
+    "test:jwt": "NODE_ENV=test AUTH_TYPE=JWT mocha --config ./test/mocharc.js ./test",
     "lint": "eslint .",
     "depcheck": "depcheck",
     "start": "NODE_ENV=production node app/index.js",
     "dev": "NODE_ENV=development nodemon app/index.js | pino-colada",
-    "coverage": "nyc npm run test"
+    "coverage": "LOG_LEVEL=fatal NODE_ENV=development nyc mocha --recursive ./test/integration --timeout 60000 --slow 20000 --exit",
+    "coverage:merge": "LOG_LEVEL=fatal NODE_ENV=development nyc --no-clean npm run test && nyc --no-clean npm run test:jwt && nyc merge .nyc_output --timeout 60000 --slow 20000 --exit"
   },
   "repository": {
     "type": "git",

--- a/test/integration/routes.test.js
+++ b/test/integration/routes.test.js
@@ -14,8 +14,11 @@ const USER_ALICE_TOKEN = '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY'
 const ALICE_STASH = '5GNJqTPyNqANBkUVMN1LPPrxXnFouWXoe2wNSmmEoLctxiZY'
 const USER_BOB_TOKEN = '5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty'
 const BOB_STASH = '5HpG9w8EBLe5XCrbczpwq5TSXvedjrBGCwqxK1iQ7qUsSWFc'
-const { AUTH_ISSUER, AUTH_AUDIENCE } = require('../../app/env')
+const { AUTH_ISSUER, AUTH_AUDIENCE, AUTH_TYPE } = require('../../app/env')
 const { cleanup } = require('../seeds/members')
+
+const describeAuthOnly = AUTH_TYPE === 'JWT' ? describe : describe.skip
+const describeNoAuthOnly = AUTH_TYPE === 'NONE' ? describe : describe.skip
 
 describe('routes', function () {
   this.timeout(3000)
@@ -29,7 +32,7 @@ describe('routes', function () {
     nock.cleanAll()
   })
 
-  describe('authenticated routes', function () {
+  describeAuthOnly('authenticated', function () {
     let app
     let jwksMock
     let authToken
@@ -175,8 +178,85 @@ describe('routes', function () {
       expect(res.body).deep.equal(expectedResult)
     })
 
-    test('get self address or returmn default', async function () {
+    test('get self address or return default', async function () {
       const { status, text } = await getSelfAddress(app, authToken)
+      expect(status).to.equal(200)
+      expect(text).to.equal('5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty')
+    })
+  })
+
+  describeNoAuthOnly('authenticated', function () {
+    let app
+
+    before(async function () {
+      await cleanup()
+
+      app = await createHttpServer()
+    })
+
+    afterEach(async function () {
+      await cleanup()
+    })
+
+    test('return membership members', async function () {
+      const expectedResult = [
+        { address: USER_BOB_TOKEN, alias: null },
+        { address: ALICE_STASH, alias: null },
+        { address: USER_ALICE_TOKEN, alias: null },
+        { address: BOB_STASH, alias: null },
+      ]
+
+      const res = await getMembersRoute(app, null)
+
+      expect(res.status).to.equal(200)
+      expect(res.body).deep.equal(expectedResult)
+    })
+
+    test('return membership members with aliases', async function () {
+      const expectedResult = [
+        { address: USER_BOB_TOKEN, alias: null },
+        { address: ALICE_STASH, alias: 'ALICE_STASH' },
+        { address: USER_ALICE_TOKEN, alias: null },
+        { address: BOB_STASH, alias: null },
+      ]
+
+      await putMemberAliasRoute(app, null, ALICE_STASH, { alias: 'ALICE_STASH' })
+      const res = await getMembersRoute(app, null)
+
+      expect(res.status).to.equal(200)
+      expect(res.body).deep.equal(expectedResult)
+    })
+
+    test('get member by alias', async function () {
+      await putMemberAliasRoute(app, null, ALICE_STASH, { alias: 'ALICE_STASH' })
+
+      const expectedResult = {
+        address: '5GNJqTPyNqANBkUVMN1LPPrxXnFouWXoe2wNSmmEoLctxiZY',
+        alias: 'ALICE_STASH',
+      }
+
+      const res = await getMemberByAliasOrAddressRoute(app, 'ALICE_STASH', null)
+
+      expect(res.status).to.equal(200)
+      expect(res.body).deep.equal(expectedResult)
+    })
+
+    test('get member by address', async function () {
+      await putMemberAliasRoute(app, null, ALICE_STASH, { alias: 'ALICE_STASH' })
+
+      const expectedResult = {
+        address: '5GNJqTPyNqANBkUVMN1LPPrxXnFouWXoe2wNSmmEoLctxiZY',
+        alias: 'ALICE_STASH',
+      }
+
+      const res = await getMemberByAliasOrAddressRoute(app, '5GNJqTPyNqANBkUVMN1LPPrxXnFouWXoe2wNSmmEoLctxiZY', null)
+
+      expect(res.status).to.equal(200)
+      expect(res.body).deep.equal(expectedResult)
+    })
+
+    test('get self address or return default', async function () {
+      const { status, text } = await getSelfAddress(app, null)
       expect(status).to.equal(200)
       expect(text).to.equal('5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty')
     })

--- a/test/integration/routes.test.js
+++ b/test/integration/routes.test.js
@@ -185,7 +185,7 @@ describe('routes', function () {
     })
   })
 
-  describeNoAuthOnly('authenticated', function () {
+  describeNoAuthOnly('no auth', function () {
     let app
 
     before(async function () {


### PR DESCRIPTION
Make it so the service can be run with/without authentication based on an env.

Very similar to https://github.com/digicatapult/dscp-api/pull/45 and https://github.com/digicatapult/dscp-api/pull/46

- [x] add `AUTH_TYPE` env + readme + helm
- [x] make jwt verification, OpenAPI spec, security handlers and other AUTH envs conditional on `AUTH_TYPE`
- [x] split tests into auth by JWT, no auth and both
- [x] add an `nyc merge` for complete code coverage
- [x] use matrix to run both in GitHub CI  
- [x] new tests for no auth