### PR TITLE
Bug/remove unused AUTH_TOKEN_URL env

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,12 +60,11 @@ npx knex migrate:latest --env test
 
 The following environment variables are additionally used when `AUTH_TYPE : 'JWT'`
 
-| variable       | required |                       default                       | description                                                           |
-| :------------- | :------: | :-------------------------------------------------: | :-------------------------------------------------------------------- |
-| AUTH_JWKS_URI  |    N     | `https://inteli.eu.auth0.com/.well-known/jwks.json` | JSON Web Key Set containing public keys used by the Auth0 API         |
-| AUTH_AUDIENCE  |    N     |                    `inteli-dev`                     | Identifier of the Auth0 API                                           |
-| AUTH_ISSUER    |    N     |           `https://inteli.eu.auth0.com/`            | Domain of the Auth0 API `                                             |
-| AUTH_TOKEN_URL |    N     |      `https://inteli.eu.auth0.com/oauth/token`      | Auth0 API endpoint that issues an Authorisation (Bearer) access token |
+| variable      | required |                       default                       | description                                                   |
+| :------------ | :------: | :-------------------------------------------------: | :------------------------------------------------------------ |
+| AUTH_JWKS_URI |    N     | `https://inteli.eu.auth0.com/.well-known/jwks.json` | JSON Web Key Set containing public keys used by the Auth0 API |
+| AUTH_AUDIENCE |    N     |                    `inteli-dev`                     | Identifier of the Auth0 API                                   |
+| AUTH_ISSUER   |    N     |           `https://inteli.eu.auth0.com/`            | Domain of the Auth0 API `                                     |
 
 ## Running the API
 

--- a/app/env.js
+++ b/app/env.js
@@ -15,7 +15,6 @@ const AUTH_ENVS = {
     AUTH_JWKS_URI: envalid.url({ devDefault: 'https://inteli.eu.auth0.com/.well-known/jwks.json' }),
     AUTH_AUDIENCE: envalid.str({ devDefault: 'inteli-dev' }),
     AUTH_ISSUER: envalid.url({ devDefault: 'https://inteli.eu.auth0.com/' }),
-    AUTH_TOKEN_URL: envalid.url({ devDefault: 'https://inteli.eu.auth0.com/oauth/token' }),
   },
 }
 

--- a/helm/dscp-identity-service/Chart.yaml
+++ b/helm/dscp-identity-service/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: dscp-identity-service
-appVersion: '1.3.0'
+appVersion: '1.3.1'
 description: A Helm chart for dscp-identity-service
-version: '1.3.0'
+version: '1.3.1'
 type: application
 maintainers:
   - name: digicatapult

--- a/helm/dscp-identity-service/templates/configmap.yaml
+++ b/helm/dscp-identity-service/templates/configmap.yaml
@@ -15,7 +15,6 @@ data:
   authJwksUri: {{ .Values.config.auth.jwksUri | quote }}
   authAudience: {{ .Values.config.auth.audience | quote }}
   authIssuer: {{ .Values.config.auth.issuer | quote }}
-  authTokenUrl: {{ .Values.config.auth.tokenUrl | quote }}
   {{- end }}
   selfAddress: {{ .Values.config.selfAddress }}
   authType: {{ .Values.config.auth.type }}

--- a/helm/dscp-identity-service/templates/deployment.yaml
+++ b/helm/dscp-identity-service/templates/deployment.yaml
@@ -92,11 +92,6 @@ spec:
                 configMapKeyRef:
                   name: {{ include "dscp-identity-service.fullname" . }}-config
                   key: authIssuer
-            - name: AUTH_TOKEN_URL
-              valueFrom:
-                configMapKeyRef:
-                  name: {{ include "dscp-identity-service.fullname" . }}-config
-                  key: authTokenUrl
             {{- end }}
             - name: DB_HOST
               valueFrom:

--- a/helm/dscp-identity-service/values.yaml
+++ b/helm/dscp-identity-service/values.yaml
@@ -12,7 +12,6 @@ config:
     jwksUri: https://dscp.eu.auth0.com/.well-known/jwks.json
     audience: dscp-test
     issuer: https://dscp.eu.auth0.com/
-    tokenUrl: https://dscp.eu.auth0.com/oauth/token
 
 ingress:
   # annotations: {}

--- a/helm/dscp-identity-service/values.yaml
+++ b/helm/dscp-identity-service/values.yaml
@@ -24,7 +24,7 @@ replicaCount: 1
 image:
   repository: ghcr.io/digicatapult/dscp-identity-service
   pullPolicy: IfNotPresent
-  tag: 'v1.3.0'
+  tag: 'v1.3.1'
   pullSecrets: ['ghcr-digicatapult']
 
 postgresql:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/dscp-identity-service",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/dscp-identity-service",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@digicatapult/dscp-node": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/dscp-identity-service",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Identity Service for DSCP",
   "main": "app/index.js",
   "scripts": {

--- a/test/test.env
+++ b/test/test.env
@@ -3,7 +3,6 @@ LOG_LEVEL=fatal
 PORT=3000
 API_HOST=localhost
 API_PORT=9944
-AUTH_TOKEN_URL=https://mock-auth-service
 AUTH_JWKS_URI=https://mock-auth-service/.well-known/jwks.json
 AUTH_AUDIENCE=mock-audience
 AUTH_ISSUER=https://mock-auth-service


### PR DESCRIPTION
Removes the `AUTH_TOKEN_URL` env which will never be used as part of this service. 