### PR TITLE
Add configration of EXTERNAL_URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ npx knex migrate:latest --env test
 | :---------------- | :------: | :-----: | :------------------------------------------------------------------------------------------- |
 | SERVICE_TYPE      |    N     | `info`  | Logging level. Valid values are [`trace`, `debug`, `info`, `warn`, `error`, `fatal`]         |
 | PORT              |    N     | `3001`  | The port for the API to listen on                                                            |
-| EXTERNAL_URL      |    N     |         | The url from which the OpenAPI service is accessible. If not provided the value will default to `http://localhost:${PORT}/${API_MAJOR_VERSION}` |
+| EXTERNAL_ORIGIN   |    N     |         | The origin from which the OpenAPI service is accessible. If not provided the value will default to `http://localhost:${PORT}` |
+| EXTERNAL_PATH_PREFIX |    N     |        | A path prefix from which this service is served |
 | LOG_LEVEL         |    N     | `info`  | Logging level. Valid values are [`trace`, `debug`, `info`, `warn`, `error`, `fatal`]         |
 | API_VERSION       |    N     |    -    | API version                                                                                  |
 | API_MAJOR_VERSION |    N     |    -    | API major version                                                                            |

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ npx knex migrate:latest --env test
 | :---------------- | :------: | :-----: | :------------------------------------------------------------------------------------------- |
 | SERVICE_TYPE      |    N     | `info`  | Logging level. Valid values are [`trace`, `debug`, `info`, `warn`, `error`, `fatal`]         |
 | PORT              |    N     | `3001`  | The port for the API to listen on                                                            |
+| EXTERNAL_URL      |    N     |         | The url from which the OpenAPI service is accessible. If not provided the value will default to `http://localhost:${PORT}/${API_MAJOR_VERSION}` |
 | LOG_LEVEL         |    N     | `info`  | Logging level. Valid values are [`trace`, `debug`, `info`, `warn`, `error`, `fatal`]         |
 | API_VERSION       |    N     |    -    | API version                                                                                  |
 | API_MAJOR_VERSION |    N     |    -    | API major version                                                                            |

--- a/app/api-v1/api-doc.js
+++ b/app/api-v1/api-doc.js
@@ -1,4 +1,10 @@
-const { PORT, API_VERSION, API_MAJOR_VERSION, EXTERNAL_URL } = require('../env')
+const { PORT, API_VERSION, API_MAJOR_VERSION, EXTERNAL_ORIGIN, EXTERNAL_PATH_PREFIX } = require('../env')
+
+let url = EXTERNAL_ORIGIN || `http://localhost:${PORT}`
+if (EXTERNAL_PATH_PREFIX) {
+  url = `${url}/${EXTERNAL_PATH_PREFIX}`
+}
+url = `${url}/${API_MAJOR_VERSION}`
 
 const apiDoc = {
   openapi: '3.0.3',
@@ -8,7 +14,7 @@ const apiDoc = {
   },
   servers: [
     {
-      url: EXTERNAL_URL || `http://localhost:${PORT}/${API_MAJOR_VERSION}`,
+      url,
     },
   ],
   components: {

--- a/app/api-v1/api-doc.js
+++ b/app/api-v1/api-doc.js
@@ -1,4 +1,4 @@
-const { PORT, API_VERSION, API_MAJOR_VERSION } = require('../env')
+const { PORT, API_VERSION, API_MAJOR_VERSION, EXTERNAL_URL } = require('../env')
 
 const apiDoc = {
   openapi: '3.0.3',
@@ -8,7 +8,7 @@ const apiDoc = {
   },
   servers: [
     {
-      url: `http://localhost:${PORT}/${API_MAJOR_VERSION}`,
+      url: EXTERNAL_URL || `http://localhost:${PORT}/${API_MAJOR_VERSION}`,
     },
   ],
   components: {

--- a/app/env.js
+++ b/app/env.js
@@ -39,6 +39,7 @@ const vars = envalid.cleanEnv(
     DB_NAME: envalid.str({ default: 'dscp' }),
     DB_USERNAME: envalid.str({ devDefault: 'postgres' }),
     DB_PASSWORD: envalid.str({ devDefault: 'postgres' }),
+    EXTERNAL_URL: envalid.str({ default: '' }),
   },
   {
     strict: true,

--- a/app/env.js
+++ b/app/env.js
@@ -39,7 +39,8 @@ const vars = envalid.cleanEnv(
     DB_NAME: envalid.str({ default: 'dscp' }),
     DB_USERNAME: envalid.str({ devDefault: 'postgres' }),
     DB_PASSWORD: envalid.str({ devDefault: 'postgres' }),
-    EXTERNAL_URL: envalid.str({ default: '' }),
+    EXTERNAL_ORIGIN: envalid.str({ default: '' }),
+    EXTERNAL_PATH_PREFIX: envalid.str({ default: '' }),
   },
   {
     strict: true,

--- a/app/server.js
+++ b/app/server.js
@@ -7,7 +7,7 @@ const path = require('path')
 const bodyParser = require('body-parser')
 const compression = require('compression')
 
-const { PORT, API_VERSION, API_MAJOR_VERSION, AUTH_TYPE } = require('./env')
+const { PORT, API_VERSION, API_MAJOR_VERSION, AUTH_TYPE, EXTERNAL_URL } = require('./env')
 const logger = require('./logger')
 const v1ApiDoc = require('./api-v1/api-doc')
 const v1ApiService = require('./api-v1/services/apiService')
@@ -54,7 +54,7 @@ async function createHttpServer() {
     swaggerOptions: {
       urls: [
         {
-          url: `http://localhost:${PORT}/${API_MAJOR_VERSION}/api-docs`,
+          url: EXTERNAL_URL ? `${EXTERNAL_URL}/api-docs` : `../api-docs`,
           name: 'IdentityService',
         },
       ],

--- a/app/server.js
+++ b/app/server.js
@@ -62,7 +62,7 @@ async function createHttpServer() {
   }
 
   app.use(
-    EXTERNAL_PATH_PREFIX ? `${EXTERNAL_PATH_PREFIX}/${API_MAJOR_VERSION}/swagger` : `/${API_MAJOR_VERSION}/swagger`,
+    EXTERNAL_PATH_PREFIX ? `/${EXTERNAL_PATH_PREFIX}/${API_MAJOR_VERSION}/swagger` : `/${API_MAJOR_VERSION}/swagger`,
     swaggerUi.serve,
     swaggerUi.setup(null, options)
   )

--- a/app/server.js
+++ b/app/server.js
@@ -7,7 +7,7 @@ const path = require('path')
 const bodyParser = require('body-parser')
 const compression = require('compression')
 
-const { PORT, API_VERSION, API_MAJOR_VERSION, AUTH_TYPE, EXTERNAL_URL } = require('./env')
+const { PORT, API_VERSION, API_MAJOR_VERSION, AUTH_TYPE, EXTERNAL_PATH_PREFIX } = require('./env')
 const logger = require('./logger')
 const v1ApiDoc = require('./api-v1/api-doc')
 const v1ApiService = require('./api-v1/services/apiService')
@@ -54,14 +54,18 @@ async function createHttpServer() {
     swaggerOptions: {
       urls: [
         {
-          url: EXTERNAL_URL ? `${EXTERNAL_URL}/api-docs` : `../api-docs`,
+          url: `${v1ApiDoc.servers[0].url}/api-docs`,
           name: 'IdentityService',
         },
       ],
     },
   }
 
-  app.use(`/${API_MAJOR_VERSION}/swagger`, swaggerUi.serve, swaggerUi.setup(null, options))
+  app.use(
+    EXTERNAL_PATH_PREFIX ? `${EXTERNAL_PATH_PREFIX}/${API_MAJOR_VERSION}/swagger` : `/${API_MAJOR_VERSION}/swagger`,
+    swaggerUi.serve,
+    swaggerUi.setup(null, options)
+  )
 
   // Sorry - app.use checks arity
   // eslint-disable-next-line no-unused-vars
@@ -72,6 +76,12 @@ async function createHttpServer() {
       logger.error('Fallback Error %j', err.stack)
       res.status(500).send('Fatal error!')
     }
+  })
+
+  logger.trace('Registered Express routes: %s', {
+    toString: () => {
+      return JSON.stringify(app._router.stack.map(({ route }) => route && route.path).filter((p) => !!p))
+    },
   })
 
   return { app }

--- a/helm/dscp-identity-service/Chart.yaml
+++ b/helm/dscp-identity-service/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: dscp-identity-service
-appVersion: '1.7.0'
+appVersion: '1.7.1'
 description: A Helm chart for dscp-identity-service
-version: '1.7.0'
+version: '1.7.1'
 type: application
 maintainers:
   - name: digicatapult

--- a/helm/dscp-identity-service/templates/configmap.yaml
+++ b/helm/dscp-identity-service/templates/configmap.yaml
@@ -7,6 +7,9 @@ metadata:
 data:
   nodeHost: {{ include "dscp-identity-service.node-host" . }}
   port: {{ .Values.config.port | quote }}
+  {{- if .Values.config.externalUrl }}
+  externalUrl: {{ .Values.config.externalUrl }}
+  {{- end }}
   logLevel: {{ .Values.config.logLevel }}
   dbHost: {{ include "dscp-identity-service.postgresql.fullname" . }}
   dbPort: {{ .Values.config.dbPort | quote }}

--- a/helm/dscp-identity-service/templates/configmap.yaml
+++ b/helm/dscp-identity-service/templates/configmap.yaml
@@ -7,8 +7,11 @@ metadata:
 data:
   nodeHost: {{ include "dscp-identity-service.node-host" . }}
   port: {{ .Values.config.port | quote }}
-  {{- if .Values.config.externalUrl }}
-  externalUrl: {{ .Values.config.externalUrl }}
+  {{- if .Values.config.externalOrigin }}
+  externalOrigin: {{ .Values.config.externalOrigin }}
+  {{- end }}
+  {{- if .Values.config.externalPathPrefix }}
+  externalPathPrefix: {{ .Values.config.externalPathPrefix }}
   {{- end }}
   logLevel: {{ .Values.config.logLevel }}
   dbHost: {{ include "dscp-identity-service.postgresql.fullname" . }}

--- a/helm/dscp-identity-service/templates/deployment.yaml
+++ b/helm/dscp-identity-service/templates/deployment.yaml
@@ -67,6 +67,13 @@ spec:
                 configMapKeyRef:
                   name: {{ include "dscp-identity-service.fullname" . }}-config
                   key: port
+            {{- if .Values.config.externalUrl }}
+            - name: EXTERNAL_URL
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "dscp-identity-service.fullname" . }}-config
+                  key: externalUrl
+            {{- end }}
             - name: LOG_LEVEL
               valueFrom:
                 configMapKeyRef:

--- a/helm/dscp-identity-service/templates/deployment.yaml
+++ b/helm/dscp-identity-service/templates/deployment.yaml
@@ -67,12 +67,19 @@ spec:
                 configMapKeyRef:
                   name: {{ include "dscp-identity-service.fullname" . }}-config
                   key: port
-            {{- if .Values.config.externalUrl }}
-            - name: EXTERNAL_URL
+            {{- if .Values.config.externalOrigin }}
+            - name: EXTERNAL_ORIGIN
               valueFrom:
                 configMapKeyRef:
                   name: {{ include "dscp-identity-service.fullname" . }}-config
-                  key: externalUrl
+                  key: externalOrigin
+            {{- end }}
+            {{- if .Values.config.externalPathPrefix }}
+            - name: EXTERNAL_PATH_PREFIX
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "dscp-identity-service.fullname" . }}-config
+                  key: externalPathPrefix
             {{- end }}
             - name: LOG_LEVEL
               valueFrom:

--- a/helm/dscp-identity-service/values.yaml
+++ b/helm/dscp-identity-service/values.yaml
@@ -1,6 +1,7 @@
 config:
   # externalNodeHost: "" # This overrides dscpNode.enabled when setting the API_HOST envar
   port: 80
+  # externalUrl: "http://localhost:3000/v3" # Overrides the server url in the openapi spec
   logLevel: info
   dbName: dscp
   dbPort: 5432
@@ -30,7 +31,7 @@ service:
 image:
   repository: digicatapult/dscp-identity-service
   pullPolicy: IfNotPresent
-  tag: 'v1.7.0'
+  tag: 'v1.7.1'
   pullSecrets: ['ghcr-digicatapult']
 
 postgresql:

--- a/helm/dscp-identity-service/values.yaml
+++ b/helm/dscp-identity-service/values.yaml
@@ -1,7 +1,8 @@
 config:
   # externalNodeHost: "" # This overrides dscpNode.enabled when setting the API_HOST envar
   port: 80
-  # externalUrl: "http://localhost:3000/v3" # Overrides the server url in the openapi spec
+  # externalOrigin: "http://localhost:3000" # Overrides the server url in the openapi spec
+  # externalPathPrefix: "alice/dscp-identity-service" # Path prefix to be applied to served API routes
   logLevel: info
   dbName: dscp
   dbPort: 5432

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/dscp-identity-service",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/dscp-identity-service",
-      "version": "1.7.0",
+      "version": "1.7.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@digicatapult/dscp-node": "^4.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/dscp-identity-service",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "Identity Service for DSCP",
   "main": "app/index.js",
   "scripts": {


### PR DESCRIPTION
Adds the env `EXTERNAL_URL` which if provided will override the url field in the published openapi spec.