### PR TITLE
Add data monitoring to dscp-identity-service

### DIFF
--- a/app/server.js
+++ b/app/server.js
@@ -12,6 +12,7 @@ import logger from './logger.js'
 import v1ApiDoc from './api-v1/api-doc.js'
 import v1ApiService from './api-v1/services/apiService.js'
 import { verifyJwks } from './util/authUtil.js'
+import promBundle from 'express-prom-bundle'
 
 const { PORT, API_VERSION, API_MAJOR_VERSION, AUTH_TYPE, EXTERNAL_PATH_PREFIX } = env
 
@@ -26,6 +27,17 @@ export async function createHttpServer() {
   app.use(cors())
   app.use(compression())
   app.use(bodyParser.json())
+
+  app.use(
+    promBundle({
+      includePath: true,
+      promClient: {
+        collectDefaultMetrics: {
+          prefix: 'identity_service_',
+        },
+      },
+    })
+  )
 
   app.get('/health', async (req, res) => {
     res.status(200).send({ version: API_VERSION, status: 'ok' })

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/dscp-identity-service",
-  "version": "1.7.3",
+  "version": "1.7.4",
   "description": "Identity Service for DSCP",
   "type": "module",
   "main": "app/index.js",

--- a/test/integration/httpServer.test.js
+++ b/test/integration/httpServer.test.js
@@ -4,13 +4,17 @@ import { expect } from 'chai'
 import { createHttpServer } from '../../app/server.js'
 import env from '../../app/env.js'
 import { healthCheck } from '../helper/routeHelper.js'
+import client from 'prom-client'
 
 describe('health', function () {
   let app
 
   before(async function () {
+    client.register.clear()
     app = await createHttpServer()
   })
+
+  afterEach(function () {})
 
   test('health check', async function () {
     const expectedResult = { status: 'ok', version: env.API_VERSION }

--- a/test/integration/routes.test.js
+++ b/test/integration/routes.test.js
@@ -12,6 +12,7 @@ import {
 } from '../helper/routeHelper.js'
 import env from '../../app/env.js'
 import { cleanup } from '../seeds/members.js'
+import client from 'prom-client'
 
 const createJWKSMock = mockJwks.default
 
@@ -55,6 +56,7 @@ describe('routes', function () {
     })
 
     after(async function () {
+      client.register.clear()
       await jwksMock.stop()
     })
 
@@ -204,6 +206,7 @@ describe('routes', function () {
     let app
 
     before(async function () {
+      client.register.clear()
       await cleanup()
 
       app = await createHttpServer()


### PR DESCRIPTION
Uses the DSCP-IPFS monitoring work done by @n3op2 to add the `prom-bundle` for metric collection. A few extra amendments were made to clear the server in the tests so they pass and avoid `Error: Cannot add the default metrics twice to the same registry`.
