### PR TITLE
Rename DSCP to Veritable

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -34,7 +34,7 @@ This Code of Conduct applies both within project spaces and in public spaces whe
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behaviour may be reported by contacting the project team at [opensource@digicatapult.org.uk](mailto:opensource@digicatapult.org.uk?subject=DSCP). All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances. The project team's obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+Instances of abusive, harassing, or otherwise unacceptable behaviour may be reported by contacting the project team at [opensource@digicatapult.org.uk](mailto:opensource@digicatapult.org.uk?subject=Veritable). All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances. The project team's obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
 
 Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,8 @@
-# Contributing to dscp-identity-service
+# Contributing to veritable-identity-service
 
 Firstly, we would like to thank you for taking the time to contribute!
 
-The following is a set of guidelines for contributing to DSCP and its packages, which are hosted on the [digicatapult](https://github.com/digicatapult) organisation on GitHub. These are mostly guidelines, not rules. Use your best judgement, and feel free to propose changes to this document in a pull request.
+The following is a set of guidelines for contributing to Veritable and its packages, which are hosted on the [digicatapult](https://github.com/digicatapult) organisation on GitHub. These are mostly guidelines, not rules. Use your best judgement, and feel free to propose changes to this document in a pull request.
 
 #### Table Of Contents
 
@@ -24,7 +24,7 @@ The following is a set of guidelines for contributing to DSCP and its packages, 
 
 ## Code of Conduct
 
-This project and all those participating in it are governed by the [Digital Catapult's Code of Conduct](CODE_OF_CONDUCT.md). By participating, you are expected to uphold this code. Please report unacceptable behaviour to [opensource@digicatapult.org.uk](mailto:opensource@digicatapult.org.uk?subject=DSCP).
+This project and all those participating in it are governed by the [Digital Catapult's Code of Conduct](CODE_OF_CONDUCT.md). By participating, you are expected to uphold this code. Please report unacceptable behaviour to [opensource@digicatapult.org.uk](mailto:opensource@digicatapult.org.uk?subject=Veritable).
 
 ## FAQs
 
@@ -34,7 +34,7 @@ We don't have any frequently asked questions yet.
 
 ### Reporting Bugs
 
-This section guides you through submitting a bug report for dscp-identity-service. Following these guidelines helps maintainers and the community understand your report :pencil:, reproduce the behaviour :computer: :computer:, and find related reports :mag_right:.
+This section guides you through submitting a bug report for veritable-identity-service. Following these guidelines helps maintainers and the community understand your report :pencil:, reproduce the behaviour :computer: :computer:, and find related reports :mag_right:.
 
 Before creating bug reports, please check [this list](#before-submitting-a-bug-report) as you might find out that you don't need to create one. When you are creating a bug report, please [include as many details as possible](#how-do-i-submit-a-good-bug-report). Fill out [the required template](https://github.com/digicatapult/dscp-identity-service/blob/main/.github/ISSUE_TEMPLATE/bug_report.md), the information it asks for helps us resolve issues faster.
 
@@ -56,24 +56,24 @@ Explain the problem and include additional details to help maintainers reproduce
 - **Describe the behaviour you observed after following the steps** and point out what exactly is the problem with that behaviour.
 - **Explain which behaviour you expected to see instead and why.**
 - **Include screenshots and animated GIFs** which show you following the described steps and clearly demonstrate the problem. If you use the keyboard while following the steps, \*\*record the GIF with the [this tool](https://www.cockos.com/licecap/) to record GIFs on macOS and Windows, and [this tool](https://github.com/colinkeenan/silentcast) or [this tool](https://github.com/Xaviju/byzanzUI) on Linux.
-- **If you're reporting that dscp-identity-service crashed**, include a crash report with a stack trace from the operating system. On macOS, the crash report will be available in `Console.app` under "Diagnostic and usage information" > "User diagnostic reports". Include the crash report in the issue in a [code block](https://help.github.com/articles/markdown-basics/#multiple-lines), a [file attachment](https://help.github.com/articles/file-attachments-on-issues-and-pull-requests/), or put it in a [gist](https://gist.github.com/) and provide link to that gist.
+- **If you're reporting that veritable-identity-service crashed**, include a crash report with a stack trace from the operating system. On macOS, the crash report will be available in `Console.app` under "Diagnostic and usage information" > "User diagnostic reports". Include the crash report in the issue in a [code block](https://help.github.com/articles/markdown-basics/#multiple-lines), a [file attachment](https://help.github.com/articles/file-attachments-on-issues-and-pull-requests/), or put it in a [gist](https://gist.github.com/) and provide link to that gist.
 - **If the problem wasn't triggered by a specific action**, describe what you were doing before the problem happened and share more information using the guidelines below.
 
 Provide more context by answering these questions:
 
-- **Did the problem start happening recently** (e.g. after updating to a new version of dscp-identity-service) or was this always a problem?
-- If the problem started happening recently, **can you reproduce the problem in an older version of dscp-identity-service?** What's the most recent version in which the problem doesn't happen? You can checkout older versions of dscp-identity-service from [the releases page](https://github.com/digicatapult/dscp-identity-service/releases).
+- **Did the problem start happening recently** (e.g. after updating to a new version of veritable-identity-service) or was this always a problem?
+- If the problem started happening recently, **can you reproduce the problem in an older version of veritable-identity-service?** What's the most recent version in which the problem doesn't happen? You can checkout older versions of veritable-identity-service from [the releases page](https://github.com/digicatapult/dscp-identity-service/releases).
 - **Can you reliably reproduce the issue?** If not, provide details about how often the problem happens and under which conditions it normally happens.
 
 Include details about your configuration and environment:
 
-- **Which version of dscp-identity-service are you using?** You can get the exact version from the version attribute within package.json.
-- **What's the name and version of the OS you've deployed dscp-identity-service to**?
-- **Are you running dscp-identity-service in a virtual machine?** If so, which VM software are you using and which operating systems and versions are used for the host and the guest?
+- **Which version of veritable-identity-service are you using?** You can get the exact version from the version attribute within package.json.
+- **What's the name and version of the OS you've deployed veritable-identity-service to**?
+- **Are you running veritable-identity-service in a virtual machine?** If so, which VM software are you using and which operating systems and versions are used for the host and the guest?
 
 ### Suggesting Enhancements
 
-This section guides you through submitting an enhancement suggestion for dscp-identity-service, including completely new features and minor improvements to existing functionality. Following these guidelines helps maintainers and the community understand your suggestion :pencil: and find related suggestions :mag_right:.
+This section guides you through submitting an enhancement suggestion for veritable-identity-service, including completely new features and minor improvements to existing functionality. Following these guidelines helps maintainers and the community understand your suggestion :pencil: and find related suggestions :mag_right:.
 
 Before creating enhancement suggestions, please check [this list](#before-submitting-an-enhancement-suggestion) as you might find out that you don't need to create one. When you are creating an enhancement suggestion, please [include as many details as possible](#how-do-i-submit-a-good-enhancement-suggestion). Fill in [the template](https://github.com/digicatapult/dscp-identity-service/blob/main/.github/ISSUE_TEMPLATE/feature_request.md), including the steps that you imagine you would take if the feature you're requesting existed.
 
@@ -89,19 +89,19 @@ Enhancement suggestions are tracked as [GitHub issues](https://guides.github.com
 - **Provide a step-by-step description of the suggested enhancement** in as many details as possible.
 - **Provide specific examples to demonstrate the steps**. Include copy/pasteable snippets which you use in those examples, as [Markdown code blocks](https://help.github.com/articles/markdown-basics/#multiple-lines).
 - **Describe the current behaviour** and **explain which behaviour you expected to see instead** and why.
-- **Include screenshots and animated GIFs** which help you demonstrate the steps or point out the part of dscp-identity-service which the suggestion is related to. You can use [this tool](https://www.cockos.com/licecap/) to record GIFs on macOS and Windows, and [this tool](https://github.com/colinkeenan/silentcast) or [this tool](https://github.com/GNOME/byzanz) on Linux.
-- **Explain why this enhancement would be useful** to most dscp-identity-service users.
+- **Include screenshots and animated GIFs** which help you demonstrate the steps or point out the part of veritable-identity-service which the suggestion is related to. You can use [this tool](https://www.cockos.com/licecap/) to record GIFs on macOS and Windows, and [this tool](https://github.com/colinkeenan/silentcast) or [this tool](https://github.com/GNOME/byzanz) on Linux.
+- **Explain why this enhancement would be useful** to most veritable-identity-service users.
 - **List some other text editors or applications where this enhancement exists.**
-- **Specify which version of dscp-identity-service you're using.** You can get the exact version from the version attribute within package.json.
-- **What's the name and version of the OS you've deployed dscp-identity-service to**?
+- **Specify which version of veritable-identity-service you're using.** You can get the exact version from the version attribute within package.json.
+- **What's the name and version of the OS you've deployed veritable-identity-service to**?
 
 ### Pull Requests
 
 The process described here has several goals:
 
-- Maintain dscp-identity-service's quality
+- Maintain veritable-identity-service's quality
 - Fix problems that are important to users
-- Enable a sustainable system for dscp-identity-service's maintainers to review contributions
+- Enable a sustainable system for veritable-identity-service's maintainers to review contributions
 
 Please follow these steps to have your contribution considered by the maintainers:
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ npx knex migrate:latest --env test
 | API_HOST             |    Y     |    -    | The hostname of the `veritable-node` the API should connect to                                                                |
 | API_PORT             |    N     | `9944`  | The port of the `veritable-node` the API should connect to                                                                    |
 | LOG_LEVEL            |    N     | `info`  | Logging level. Valid values are [`trace`, `debug`, `info`, `warn`, `error`, `fatal`]                                          |
-| USER_URI             |    Y     |    -    | The Substrate `URI` representing the private key to use when making `dscp-node` transactions                                  |
+| USER_URI             |    Y     |    -    | The Substrate `URI` representing the private key to use when making `veritable-node` transactions                             |
 | DB_HOST              |    Y     |    -    | Hostname for the db                                                                                                           |
 | DB_PORT              |    N     |  5432   | Port to connect to the db                                                                                                     |
 | DB_NAME              |    N     | `dscp`  | Name of the database to connect to                                                                                            |

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ npx knex migrate:latest --env test
 | API_HOST             |    Y     |    -    | The hostname of the `veritable-node` the API should connect to                                                                |
 | API_PORT             |    N     | `9944`  | The port of the `veritable-node` the API should connect to                                                                    |
 | LOG_LEVEL            |    N     | `info`  | Logging level. Valid values are [`trace`, `debug`, `info`, `warn`, `error`, `fatal`]                                          |
-| USER_URI             |    Y     |    -    | The Substrate `URI` representing the private key to use when making `veritable-node` transactions                             |
+| USER_URI             |    Y     |    -    | The Substrate `URI` representing the private key to use when making `dscp-node` transactions                                  |
 | DB_HOST              |    Y     |    -    | Hostname for the db                                                                                                           |
 | DB_PORT              |    N     |  5432   | Port to connect to the db                                                                                                     |
 | DB_NAME              |    N     | `dscp`  | Name of the database to connect to                                                                                            |

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# DSCP Identity Service
+# Veritable Identity Service
 
 ## Description
 
-A `Node.js` API to support communication to the [Substrate-based](https://www.substrate.io/) [`dscp-node`](https://github.com/digicatapult/dscp-node) (via [`polkadot-js/api`](https://www.npmjs.com/package/@polkadot/api)) and an [`IPFS`](https://ipfs.io/) node.
+A `Node.js` API to support communication to the [Substrate-based](https://www.substrate.io/) [`veritable-node`](https://github.com/digicatapult/dscp-node) (via [`polkadot-js/api`](https://www.npmjs.com/package/@polkadot/api)) and an [`IPFS`](https://ipfs.io/) node.
 
 ## Getting started
 
@@ -12,12 +12,12 @@ First, ensure you're running the correct [version](.node-version) of `npm`, then
 npm install
 ```
 
-The API requires instances of Postgresql and [`dscp-node`](https://github.com/digicatapult/dscp-node).
+The API requires instances of Postgresql and [`veritable-node`](https://github.com/digicatapult/dscp-node).
 To bring this up locally:
 
-### `dscp-node`
+### `veritable-node`
 
-Clone [dscp-node](https://github.com/digicatapult/dscp-node) and follow the README to setup and build a local node. Then run the following in its root directory:
+Clone [veritable-node](https://github.com/digicatapult/dscp-node) and follow the README to setup and build a local node. Then run the following in its root directory:
 
 ```
 ./target/release/dscp-node --dev
@@ -37,28 +37,28 @@ npx knex migrate:latest --env test
 
 ## Environment Variables
 
-`dscp-identity-service` is configured primarily using environment variables as follows:
+`veritable-identity-service` is configured primarily using environment variables as follows:
 
-| variable          | required | default | description                                                                                  |
-| :---------------- | :------: | :-----: | :------------------------------------------------------------------------------------------- |
-| SERVICE_TYPE      |    N     | `info`  | Logging level. Valid values are [`trace`, `debug`, `info`, `warn`, `error`, `fatal`]         |
-| PORT              |    N     | `3001`  | The port for the API to listen on                                                            |
-| EXTERNAL_ORIGIN   |    N     |         | The origin from which the OpenAPI service is accessible. If not provided the value will default to `http://localhost:${PORT}` |
-| EXTERNAL_PATH_PREFIX |    N     |        | A path prefix from which this service is served |
-| LOG_LEVEL         |    N     | `info`  | Logging level. Valid values are [`trace`, `debug`, `info`, `warn`, `error`, `fatal`]         |
-| API_VERSION       |    N     |    -    | API version                                                                                  |
-| API_MAJOR_VERSION |    N     |    -    | API major version                                                                            |
-| API_HOST          |    Y     |    -    | The hostname of the `dscp-node` the API should connect to                                    |
-| API_PORT          |    N     | `9944`  | The port of the `dscp-node` the API should connect to                                        |
-| LOG_LEVEL         |    N     | `info`  | Logging level. Valid values are [`trace`, `debug`, `info`, `warn`, `error`, `fatal`]         |
-| USER_URI          |    Y     |    -    | The Substrate `URI` representing the private key to use when making `dscp-node` transactions |
-| DB_HOST           |    Y     |    -    | Hostname for the db                                                                          |
-| DB_PORT           |    N     |  5432   | Port to connect to the db                                                                    |
-| DB_NAME           |    N     | `dscp`  | Name of the database to connect to                                                           |
-| DB_USERNAME       |    Y     |    -    | Username to connect to the database with                                                     |
-| DB_PASSWORD       |    Y     |    -    | Password to connect to the database with                                                     |
-| SELF_ADDRESS      |    N     |    -    | Instance wallet address that is returned by `/self` endpoint                                 |
-| AUTH_TYPE         |    N     | `NONE`  | Authentication type for routes on the service. Valid values: [`NONE`, `JWT`]                 |
+| variable             | required |   default   | description                                                                                                                   |
+| :------------------- | :------: | :---------: | :---------------------------------------------------------------------------------------------------------------------------- |
+| SERVICE_TYPE         |    N     |   `info`    | Logging level. Valid values are [`trace`, `debug`, `info`, `warn`, `error`, `fatal`]                                          |
+| PORT                 |    N     |   `3001`    | The port for the API to listen on                                                                                             |
+| EXTERNAL_ORIGIN      |    N     |             | The origin from which the OpenAPI service is accessible. If not provided the value will default to `http://localhost:${PORT}` |
+| EXTERNAL_PATH_PREFIX |    N     |             | A path prefix from which this service is served                                                                               |
+| LOG_LEVEL            |    N     |   `info`    | Logging level. Valid values are [`trace`, `debug`, `info`, `warn`, `error`, `fatal`]                                          |
+| API_VERSION          |    N     |      -      | API version                                                                                                                   |
+| API_MAJOR_VERSION    |    N     |      -      | API major version                                                                                                             |
+| API_HOST             |    Y     |      -      | The hostname of the `veritable-node` the API should connect to                                                                |
+| API_PORT             |    N     |   `9944`    | The port of the `veritable-node` the API should connect to                                                                    |
+| LOG_LEVEL            |    N     |   `info`    | Logging level. Valid values are [`trace`, `debug`, `info`, `warn`, `error`, `fatal`]                                          |
+| USER_URI             |    Y     |      -      | The Substrate `URI` representing the private key to use when making `veritable-node` transactions                             |
+| DB_HOST              |    Y     |      -      | Hostname for the db                                                                                                           |
+| DB_PORT              |    N     |    5432     | Port to connect to the db                                                                                                     |
+| DB_NAME              |    N     | `veritable` | Name of the database to connect to                                                                                            |
+| DB_USERNAME          |    Y     |      -      | Username to connect to the database with                                                                                      |
+| DB_PASSWORD          |    Y     |      -      | Password to connect to the database with                                                                                      |
+| SELF_ADDRESS         |    N     |      -      | Instance wallet address that is returned by `/self` endpoint                                                                  |
+| AUTH_TYPE            |    N     |   `NONE`    | Authentication type for routes on the service. Valid values: [`NONE`, `JWT`]                                                  |
 
 The following environment variables are additionally used when `AUTH_TYPE : 'JWT'`
 
@@ -80,7 +80,7 @@ npm start
 
 ### Authenticated endpoints
 
-If `AUTH_TYPE` env is set to `JWT`, the rest of the endpoints in `dscp-identity-service` require authentication in the form of a header `'Authorization: Bearer YOUR_ACCESS_TOKEN'`:
+If `AUTH_TYPE` env is set to `JWT`, the rest of the endpoints in `veritable-identity-service` require authentication in the form of a header `'Authorization: Bearer YOUR_ACCESS_TOKEN'`:
 
 1. [GET /members/](#GET-/members)
 2. [GET /members/:address](#PUT-/members/:address)

--- a/README.md
+++ b/README.md
@@ -39,26 +39,26 @@ npx knex migrate:latest --env test
 
 `veritable-identity-service` is configured primarily using environment variables as follows:
 
-| variable             | required |   default   | description                                                                                                                   |
-| :------------------- | :------: | :---------: | :---------------------------------------------------------------------------------------------------------------------------- |
-| SERVICE_TYPE         |    N     |   `info`    | Logging level. Valid values are [`trace`, `debug`, `info`, `warn`, `error`, `fatal`]                                          |
-| PORT                 |    N     |   `3001`    | The port for the API to listen on                                                                                             |
-| EXTERNAL_ORIGIN      |    N     |             | The origin from which the OpenAPI service is accessible. If not provided the value will default to `http://localhost:${PORT}` |
-| EXTERNAL_PATH_PREFIX |    N     |             | A path prefix from which this service is served                                                                               |
-| LOG_LEVEL            |    N     |   `info`    | Logging level. Valid values are [`trace`, `debug`, `info`, `warn`, `error`, `fatal`]                                          |
-| API_VERSION          |    N     |      -      | API version                                                                                                                   |
-| API_MAJOR_VERSION    |    N     |      -      | API major version                                                                                                             |
-| API_HOST             |    Y     |      -      | The hostname of the `veritable-node` the API should connect to                                                                |
-| API_PORT             |    N     |   `9944`    | The port of the `veritable-node` the API should connect to                                                                    |
-| LOG_LEVEL            |    N     |   `info`    | Logging level. Valid values are [`trace`, `debug`, `info`, `warn`, `error`, `fatal`]                                          |
-| USER_URI             |    Y     |      -      | The Substrate `URI` representing the private key to use when making `veritable-node` transactions                             |
-| DB_HOST              |    Y     |      -      | Hostname for the db                                                                                                           |
-| DB_PORT              |    N     |    5432     | Port to connect to the db                                                                                                     |
-| DB_NAME              |    N     | `veritable` | Name of the database to connect to                                                                                            |
-| DB_USERNAME          |    Y     |      -      | Username to connect to the database with                                                                                      |
-| DB_PASSWORD          |    Y     |      -      | Password to connect to the database with                                                                                      |
-| SELF_ADDRESS         |    N     |      -      | Instance wallet address that is returned by `/self` endpoint                                                                  |
-| AUTH_TYPE            |    N     |   `NONE`    | Authentication type for routes on the service. Valid values: [`NONE`, `JWT`]                                                  |
+| variable             | required | default | description                                                                                                                   |
+| :------------------- | :------: | :-----: | :---------------------------------------------------------------------------------------------------------------------------- |
+| SERVICE_TYPE         |    N     | `info`  | Logging level. Valid values are [`trace`, `debug`, `info`, `warn`, `error`, `fatal`]                                          |
+| PORT                 |    N     | `3001`  | The port for the API to listen on                                                                                             |
+| EXTERNAL_ORIGIN      |    N     |         | The origin from which the OpenAPI service is accessible. If not provided the value will default to `http://localhost:${PORT}` |
+| EXTERNAL_PATH_PREFIX |    N     |         | A path prefix from which this service is served                                                                               |
+| LOG_LEVEL            |    N     | `info`  | Logging level. Valid values are [`trace`, `debug`, `info`, `warn`, `error`, `fatal`]                                          |
+| API_VERSION          |    N     |    -    | API version                                                                                                                   |
+| API_MAJOR_VERSION    |    N     |    -    | API major version                                                                                                             |
+| API_HOST             |    Y     |    -    | The hostname of the `veritable-node` the API should connect to                                                                |
+| API_PORT             |    N     | `9944`  | The port of the `veritable-node` the API should connect to                                                                    |
+| LOG_LEVEL            |    N     | `info`  | Logging level. Valid values are [`trace`, `debug`, `info`, `warn`, `error`, `fatal`]                                          |
+| USER_URI             |    Y     |    -    | The Substrate `URI` representing the private key to use when making `veritable-node` transactions                             |
+| DB_HOST              |    Y     |    -    | Hostname for the db                                                                                                           |
+| DB_PORT              |    N     |  5432   | Port to connect to the db                                                                                                     |
+| DB_NAME              |    N     | `dscp`  | Name of the database to connect to                                                                                            |
+| DB_USERNAME          |    Y     |    -    | Username to connect to the database with                                                                                      |
+| DB_PASSWORD          |    Y     |    -    | Password to connect to the database with                                                                                      |
+| SELF_ADDRESS         |    N     |    -    | Instance wallet address that is returned by `/self` endpoint                                                                  |
+| AUTH_TYPE            |    N     | `NONE`  | Authentication type for routes on the service. Valid values: [`NONE`, `JWT`]                                                  |
 
 The following environment variables are additionally used when `AUTH_TYPE : 'JWT'`
 

--- a/helm/dscp-identity-service/Chart.yaml
+++ b/helm/dscp-identity-service/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: dscp-identity-service
-appVersion: '1.8.1'
+appVersion: '1.8.2'
 description: A Helm chart for dscp-identity-service
-version: '1.8.1'
+version: '1.8.2'
 type: application
 maintainers:
   - name: digicatapult

--- a/helm/dscp-identity-service/Chart.yaml
+++ b/helm/dscp-identity-service/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: dscp-identity-service
-appVersion: '1.8.0'
-description: A Helm chart for dscp-identity-service
-version: '1.8.0'
+appVersion: '1.8.1'
+description: A Helm chart for veritable-identity-service
+version: '1.8.1'
 type: application
 maintainers:
   - name: digicatapult

--- a/helm/dscp-identity-service/values.yaml
+++ b/helm/dscp-identity-service/values.yaml
@@ -32,7 +32,7 @@ service:
 image:
   repository: digicatapult/dscp-identity-service
   pullPolicy: IfNotPresent
-  tag: 'v1.8.0'
+  tag: 'v1.8.1'
   pullSecrets: ['ghcr-digicatapult']
 
 postgresql:

--- a/helm/dscp-identity-service/values.yaml
+++ b/helm/dscp-identity-service/values.yaml
@@ -32,7 +32,7 @@ service:
 image:
   repository: digicatapult/dscp-identity-service
   pullPolicy: IfNotPresent
-  tag: 'v1.8.1'
+  tag: 'v1.8.2'
   pullSecrets: ['ghcr-digicatapult']
 
 postgresql:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/dscp-identity-service",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/dscp-identity-service",
-      "version": "1.8.0",
+      "version": "1.8.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@digicatapult/dscp-node": "^4.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/dscp-identity-service",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/dscp-identity-service",
-      "version": "1.8.1",
+      "version": "1.8.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@polkadot/api": "^9.9.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/dscp-identity-service",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "description": "Identity Service for DSCP",
   "type": "module",
   "main": "app/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/dscp-identity-service",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "description": "Identity Service for DSCP",
   "type": "module",
   "main": "app/index.js",


### PR DESCRIPTION
This renames `DSCP` to `Veritable` where appropriate in markdown files.
