### PR TITLE
Replace dscp-node package with @polkadot/api

### DIFF
--- a/app/util/appUtil.js
+++ b/app/util/appUtil.js
@@ -1,4 +1,4 @@
-import { buildApi } from '@digicatapult/dscp-node'
+import { ApiPromise, WsProvider } from '@polkadot/api'
 
 import env from '../env.js'
 import logger from '../logger.js'
@@ -6,12 +6,10 @@ import { getMemberAliasesDb } from '../db.js'
 
 const { API_HOST, API_PORT } = env
 
-const { api } = buildApi({
-  options: {
-    apiHost: API_HOST,
-    apiPort: API_PORT,
-  },
-})
+const provider = new WsProvider(`ws://${API_HOST}:${API_PORT}`)
+const api = new ApiPromise({ provider })
+
+api.isReadyOrError.catch(() => {}) // prevent unhandled promise rejection errors
 
 api.on('disconnected', () => {
   logger.warn(`Disconnected from substrate node at ${API_HOST}:${API_PORT}`)

--- a/helm/dscp-identity-service/Chart.yaml
+++ b/helm/dscp-identity-service/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: dscp-identity-service
-appVersion: '1.8.0'
+appVersion: '1.8.1'
 description: A Helm chart for dscp-identity-service
-version: '1.8.0'
+version: '1.8.1'
 type: application
 maintainers:
   - name: digicatapult

--- a/helm/dscp-identity-service/values.yaml
+++ b/helm/dscp-identity-service/values.yaml
@@ -32,7 +32,7 @@ service:
 image:
   repository: digicatapult/dscp-identity-service
   pullPolicy: IfNotPresent
-  tag: 'v1.8.0'
+  tag: 'v1.8.1'
   pullSecrets: ['ghcr-digicatapult']
 
 postgresql:

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.8.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@digicatapult/dscp-node": "^4.3.1",
+        "@polkadot/api": "^9.9.4",
         "body-parser": "^1.20.1",
         "compression": "^1.7.4",
         "cors": "^2.8.5",
@@ -410,11 +410,11 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.18.6.tgz",
-      "integrity": "sha512-t9wi7/AW6XtKahAe20Yw0/mMljKq0B1r2fPdvaAdV/KPDZewFXdaaa6K7lxmZBZ8FBNpCiAT6iHPmd6QO9bKfQ==",
+      "version": "7.20.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.20.6.tgz",
+      "integrity": "sha512-Q+8MqP7TiHMWzSfwiJwXCjyf4GYA4Dgw3emg/7xmwsdLJOZUp+nMqcOwOzzYheuM1rhDu8FSj2l0aoMygEuXuA==",
       "dependencies": {
-        "regenerator-runtime": "^0.13.4"
+        "regenerator-runtime": "^0.13.11"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -513,18 +513,6 @@
       },
       "engines": {
         "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@digicatapult/dscp-node": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@digicatapult/dscp-node/-/dscp-node-4.3.1.tgz",
-      "integrity": "sha512-RszD9z93VXIIK3w4Y3dnREZvsVXVtV/8fjAcHuaGornYZRH88vFoWIBfU+HD+DaK1QvJXUr51guDTfXPVuD4kw==",
-      "dependencies": {
-        "@polkadot/api": "^8.11.3"
-      },
-      "engines": {
-        "node": "16.x.x",
-        "npm": "8.x.x"
       }
     },
     "node_modules/@eslint/eslintrc": {
@@ -826,9 +814,9 @@
       }
     },
     "node_modules/@noble/hashes": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.1.2.tgz",
-      "integrity": "sha512-KYRCASVTv6aeUi1tsF8/vpyR7zpfs3FUzy2Jqm+MU+LmUKhQ0y2FpfwqkCcxSg2ua4GALJd8k2R76WxwZGbQpA==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.1.3.tgz",
+      "integrity": "sha512-CE0FCR57H2acVI5UOzIGSSIYxZ6v/HOhDR0Ro9VLyhnzLwx0o8W1mmgaqlEUx4049qJDlIBRztv5k+MM8vbO3A==",
       "funding": [
         {
           "type": "individual",
@@ -837,9 +825,9 @@
       ]
     },
     "node_modules/@noble/secp256k1": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-1.6.0.tgz",
-      "integrity": "sha512-DWSsg8zMHOYMYBqIQi96BQuthZrp98LCeMNcUOaffCIVYQ5yxDbNikLF+H7jEnmNNmXbtVic46iCuVWzar+MgA==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-1.7.0.tgz",
+      "integrity": "sha512-kbacwGSsH/CTout0ZnZWxnW1B+jH/7r/WAAKLBtrRJ/+CUH7lgmQzl3GTrQua3SGKWNSDsS6lmjnDpIJ5Dxyaw==",
       "funding": [
         {
           "type": "individual",
@@ -891,265 +879,265 @@
       }
     },
     "node_modules/@polkadot/api": {
-      "version": "8.12.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/api/-/api-8.12.2.tgz",
-      "integrity": "sha512-bK3bhCFqCYTx/K/89QF88jYqE3Dc1LmCwMnwpof6adlAj5DoEjRfSmKarqrZqox516Xph1+84ACNkyem0KnIWA==",
+      "version": "9.9.4",
+      "resolved": "https://registry.npmjs.org/@polkadot/api/-/api-9.9.4.tgz",
+      "integrity": "sha512-ze7W/DXsPHsixrFOACzugDQqezzrUGGX1Z2JOl6z+V8pd+ZKLSecsKJFUzf4yoBT82ArITYPtRVx/Dq9b9K2dA==",
       "dependencies": {
-        "@babel/runtime": "^7.18.6",
-        "@polkadot/api-augment": "8.12.2",
-        "@polkadot/api-base": "8.12.2",
-        "@polkadot/api-derive": "8.12.2",
-        "@polkadot/keyring": "^10.0.2",
-        "@polkadot/rpc-augment": "8.12.2",
-        "@polkadot/rpc-core": "8.12.2",
-        "@polkadot/rpc-provider": "8.12.2",
-        "@polkadot/types": "8.12.2",
-        "@polkadot/types-augment": "8.12.2",
-        "@polkadot/types-codec": "8.12.2",
-        "@polkadot/types-create": "8.12.2",
-        "@polkadot/types-known": "8.12.2",
-        "@polkadot/util": "^10.0.2",
-        "@polkadot/util-crypto": "^10.0.2",
+        "@babel/runtime": "^7.20.1",
+        "@polkadot/api-augment": "9.9.4",
+        "@polkadot/api-base": "9.9.4",
+        "@polkadot/api-derive": "9.9.4",
+        "@polkadot/keyring": "^10.1.14",
+        "@polkadot/rpc-augment": "9.9.4",
+        "@polkadot/rpc-core": "9.9.4",
+        "@polkadot/rpc-provider": "9.9.4",
+        "@polkadot/types": "9.9.4",
+        "@polkadot/types-augment": "9.9.4",
+        "@polkadot/types-codec": "9.9.4",
+        "@polkadot/types-create": "9.9.4",
+        "@polkadot/types-known": "9.9.4",
+        "@polkadot/util": "^10.1.14",
+        "@polkadot/util-crypto": "^10.1.14",
         "eventemitter3": "^4.0.7",
-        "rxjs": "^7.5.5"
+        "rxjs": "^7.5.7"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@polkadot/api-augment": {
-      "version": "8.12.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/api-augment/-/api-augment-8.12.2.tgz",
-      "integrity": "sha512-HbvNOu6ntago8nYqLkq/HZ+gsMhbKe/sD4hPIFPruhP6OAnW6TWNIlqc2ruFx2KrT0rfzXUZ4Gmk4WgyRFuz4Q==",
+      "version": "9.9.4",
+      "resolved": "https://registry.npmjs.org/@polkadot/api-augment/-/api-augment-9.9.4.tgz",
+      "integrity": "sha512-+T9YWw5kEi7AkSoS2UfE1nrVeJUtD92elQBZ3bMMkfM1geKWhSnvBLyTMn6kFmNXTfK0qt8YKS1pwbux7cC9tg==",
       "dependencies": {
-        "@babel/runtime": "^7.18.6",
-        "@polkadot/api-base": "8.12.2",
-        "@polkadot/rpc-augment": "8.12.2",
-        "@polkadot/types": "8.12.2",
-        "@polkadot/types-augment": "8.12.2",
-        "@polkadot/types-codec": "8.12.2",
-        "@polkadot/util": "^10.0.2"
+        "@babel/runtime": "^7.20.1",
+        "@polkadot/api-base": "9.9.4",
+        "@polkadot/rpc-augment": "9.9.4",
+        "@polkadot/types": "9.9.4",
+        "@polkadot/types-augment": "9.9.4",
+        "@polkadot/types-codec": "9.9.4",
+        "@polkadot/util": "^10.1.14"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@polkadot/api-base": {
-      "version": "8.12.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/api-base/-/api-base-8.12.2.tgz",
-      "integrity": "sha512-5rLOCulXNU/g0rUVoW6ArQjOBq/07S6oKR9nOJls6W4PUhYcBIClCTlXx2uoDszMdwhEhYyHQ67bnoTcRrYcLA==",
+      "version": "9.9.4",
+      "resolved": "https://registry.npmjs.org/@polkadot/api-base/-/api-base-9.9.4.tgz",
+      "integrity": "sha512-G1DcxcMeGcvaAAA3u5Tbf70zE5aIuAPEAXnptFMF0lvJz4O6CM8k8ZZFTSk25hjsYlnx8WI1FTc97q4/tKie+Q==",
       "dependencies": {
-        "@babel/runtime": "^7.18.6",
-        "@polkadot/rpc-core": "8.12.2",
-        "@polkadot/types": "8.12.2",
-        "@polkadot/util": "^10.0.2",
-        "rxjs": "^7.5.5"
+        "@babel/runtime": "^7.20.1",
+        "@polkadot/rpc-core": "9.9.4",
+        "@polkadot/types": "9.9.4",
+        "@polkadot/util": "^10.1.14",
+        "rxjs": "^7.5.7"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@polkadot/api-derive": {
-      "version": "8.12.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/api-derive/-/api-derive-8.12.2.tgz",
-      "integrity": "sha512-F7HCAVNXLQphv7OYVcq7GM5CP6RzGvYfTqutmc5GZFCDVMDY9RQA+a/3T5BIjJXrtepPa0pcYvt9fcovsazhZw==",
+      "version": "9.9.4",
+      "resolved": "https://registry.npmjs.org/@polkadot/api-derive/-/api-derive-9.9.4.tgz",
+      "integrity": "sha512-3ka7GzY4QbI3d/DHjQ9SjfDOTDxeU8gM2Dn31BP1oFzGwdFe2GZhDIE//lR5S6UDVxNNlgWz4927AunOQcuAmg==",
       "dependencies": {
-        "@babel/runtime": "^7.18.6",
-        "@polkadot/api": "8.12.2",
-        "@polkadot/api-augment": "8.12.2",
-        "@polkadot/api-base": "8.12.2",
-        "@polkadot/rpc-core": "8.12.2",
-        "@polkadot/types": "8.12.2",
-        "@polkadot/types-codec": "8.12.2",
-        "@polkadot/util": "^10.0.2",
-        "@polkadot/util-crypto": "^10.0.2",
-        "rxjs": "^7.5.5"
+        "@babel/runtime": "^7.20.1",
+        "@polkadot/api": "9.9.4",
+        "@polkadot/api-augment": "9.9.4",
+        "@polkadot/api-base": "9.9.4",
+        "@polkadot/rpc-core": "9.9.4",
+        "@polkadot/types": "9.9.4",
+        "@polkadot/types-codec": "9.9.4",
+        "@polkadot/util": "^10.1.14",
+        "@polkadot/util-crypto": "^10.1.14",
+        "rxjs": "^7.5.7"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@polkadot/keyring": {
-      "version": "10.0.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/keyring/-/keyring-10.0.2.tgz",
-      "integrity": "sha512-N/lx/e9alR/lUREap4hQ/YKa+CKCFIa4QOKLz8eFhpqhbA5M5nQcjrppitO+sX/XlpmbOBpbnO168cU2dA09Iw==",
+      "version": "10.1.14",
+      "resolved": "https://registry.npmjs.org/@polkadot/keyring/-/keyring-10.1.14.tgz",
+      "integrity": "sha512-iejbAfGfdyTB0pixWX6HhWXkUKBHLNy7+Z+F4DU8IwpJE48iOsMRJb3qShbk5NERjx1QIjoOpSZYxiCaF6gd+w==",
       "dependencies": {
-        "@babel/runtime": "^7.18.6",
-        "@polkadot/util": "10.0.2",
-        "@polkadot/util-crypto": "10.0.2"
+        "@babel/runtime": "^7.20.1",
+        "@polkadot/util": "10.1.14",
+        "@polkadot/util-crypto": "10.1.14"
       },
       "engines": {
         "node": ">=14.0.0"
       },
       "peerDependencies": {
-        "@polkadot/util": "10.0.2",
-        "@polkadot/util-crypto": "10.0.2"
+        "@polkadot/util": "10.1.14",
+        "@polkadot/util-crypto": "10.1.14"
       }
     },
     "node_modules/@polkadot/networks": {
-      "version": "10.0.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/networks/-/networks-10.0.2.tgz",
-      "integrity": "sha512-K7hUFmErTrBtkobhvFwT/oPEQrI1oVr7WfngquM+zN0oHiHzRspecxifGKsQ1kw78F7zrZKOBScW/hoJbdI8fA==",
+      "version": "10.1.14",
+      "resolved": "https://registry.npmjs.org/@polkadot/networks/-/networks-10.1.14.tgz",
+      "integrity": "sha512-lo4Y57yBqiad4Z2zBW0r7Ct/iKXNgsTfazDTbHRkIh3RuX36PNYshaX3p7R0eNRuetV1jJv7jqwc1nAMNI2KwQ==",
       "dependencies": {
-        "@babel/runtime": "^7.18.6",
-        "@polkadot/util": "10.0.2",
-        "@substrate/ss58-registry": "^1.23.0"
+        "@babel/runtime": "^7.20.1",
+        "@polkadot/util": "10.1.14",
+        "@substrate/ss58-registry": "^1.35.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@polkadot/rpc-augment": {
-      "version": "8.12.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/rpc-augment/-/rpc-augment-8.12.2.tgz",
-      "integrity": "sha512-FKVMmkYhWJNcuXpRN9t7xTX5agSgcgniP8gNPMhL6GV8lV3Xoxs8gLgVy32xeAh7gxArN/my6LnYPtXVkdFALQ==",
+      "version": "9.9.4",
+      "resolved": "https://registry.npmjs.org/@polkadot/rpc-augment/-/rpc-augment-9.9.4.tgz",
+      "integrity": "sha512-67zGQAhJuXd/CZlwDZTgxNt3xGtsDwLvLvyFrHuNjJNM0KGCyt/OpQHVBlyZ6xfII0WZpccASN6P2MxsGTMnKw==",
       "dependencies": {
-        "@babel/runtime": "^7.18.6",
-        "@polkadot/rpc-core": "8.12.2",
-        "@polkadot/types": "8.12.2",
-        "@polkadot/types-codec": "8.12.2",
-        "@polkadot/util": "^10.0.2"
+        "@babel/runtime": "^7.20.1",
+        "@polkadot/rpc-core": "9.9.4",
+        "@polkadot/types": "9.9.4",
+        "@polkadot/types-codec": "9.9.4",
+        "@polkadot/util": "^10.1.14"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@polkadot/rpc-core": {
-      "version": "8.12.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/rpc-core/-/rpc-core-8.12.2.tgz",
-      "integrity": "sha512-RLhzNYJonfsQXYhZuyVBSsOwSgCf+8ijS3aUcv06yrFf26k7nXw2Uc4P0Io3jY/wq5LnvkKzL+HSj6j7XZ+/Sg==",
+      "version": "9.9.4",
+      "resolved": "https://registry.npmjs.org/@polkadot/rpc-core/-/rpc-core-9.9.4.tgz",
+      "integrity": "sha512-DxhJcq1GAi+28nLMqhTksNMqTX40bGNhYuyQyy/to39VxizAjx+lyAHAMfzG9lvPnTIi2KzXif2pCdWq3AgJag==",
       "dependencies": {
-        "@babel/runtime": "^7.18.6",
-        "@polkadot/rpc-augment": "8.12.2",
-        "@polkadot/rpc-provider": "8.12.2",
-        "@polkadot/types": "8.12.2",
-        "@polkadot/util": "^10.0.2",
-        "rxjs": "^7.5.5"
+        "@babel/runtime": "^7.20.1",
+        "@polkadot/rpc-augment": "9.9.4",
+        "@polkadot/rpc-provider": "9.9.4",
+        "@polkadot/types": "9.9.4",
+        "@polkadot/util": "^10.1.14",
+        "rxjs": "^7.5.7"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@polkadot/rpc-provider": {
-      "version": "8.12.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/rpc-provider/-/rpc-provider-8.12.2.tgz",
-      "integrity": "sha512-fgXKAYDmc1kGmOPa2Nuh+LsUBFvUzgzP/tOEbS5UJpoc0+azZfTLWh2AXpo/gVHblR6zZBDWrB3wmGzu6wF17A==",
+      "version": "9.9.4",
+      "resolved": "https://registry.npmjs.org/@polkadot/rpc-provider/-/rpc-provider-9.9.4.tgz",
+      "integrity": "sha512-aUkPtlYukAOFX3FkUgLw3MNy+T0mCiCX7va3PIts9ggK4vl14NFZHurCZq+5ANvknRU4WG8P5teurH9Rd9oDjQ==",
       "dependencies": {
-        "@babel/runtime": "^7.18.6",
-        "@polkadot/keyring": "^10.0.2",
-        "@polkadot/types": "8.12.2",
-        "@polkadot/types-support": "8.12.2",
-        "@polkadot/util": "^10.0.2",
-        "@polkadot/util-crypto": "^10.0.2",
-        "@polkadot/x-fetch": "^10.0.2",
-        "@polkadot/x-global": "^10.0.2",
-        "@polkadot/x-ws": "^10.0.2",
-        "@substrate/connect": "0.7.7",
+        "@babel/runtime": "^7.20.1",
+        "@polkadot/keyring": "^10.1.14",
+        "@polkadot/types": "9.9.4",
+        "@polkadot/types-support": "9.9.4",
+        "@polkadot/util": "^10.1.14",
+        "@polkadot/util-crypto": "^10.1.14",
+        "@polkadot/x-fetch": "^10.1.14",
+        "@polkadot/x-global": "^10.1.14",
+        "@polkadot/x-ws": "^10.1.14",
+        "@substrate/connect": "0.7.17",
         "eventemitter3": "^4.0.7",
         "mock-socket": "^9.1.5",
-        "nock": "^13.2.8"
+        "nock": "^13.2.9"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@polkadot/types": {
-      "version": "8.12.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/types/-/types-8.12.2.tgz",
-      "integrity": "sha512-hOqLunz4YH51B6AvuemX1cXKf+O8pehEoP3lH+FRKfJ7wyVhqa3WA+aUXhoTQBIuSiOjjC/FEJrRO5AoNO2iCg==",
+      "version": "9.9.4",
+      "resolved": "https://registry.npmjs.org/@polkadot/types/-/types-9.9.4.tgz",
+      "integrity": "sha512-/LJ029S0AtKzvV9JoQtIIeHRP/Xoq8MZmDfdHUEgThRd+uvtQzFyGmcupe4EzX0p5VAx93DUFQKm8vUdHE39Tw==",
       "dependencies": {
-        "@babel/runtime": "^7.18.6",
-        "@polkadot/keyring": "^10.0.2",
-        "@polkadot/types-augment": "8.12.2",
-        "@polkadot/types-codec": "8.12.2",
-        "@polkadot/types-create": "8.12.2",
-        "@polkadot/util": "^10.0.2",
-        "@polkadot/util-crypto": "^10.0.2",
-        "rxjs": "^7.5.5"
+        "@babel/runtime": "^7.20.1",
+        "@polkadot/keyring": "^10.1.14",
+        "@polkadot/types-augment": "9.9.4",
+        "@polkadot/types-codec": "9.9.4",
+        "@polkadot/types-create": "9.9.4",
+        "@polkadot/util": "^10.1.14",
+        "@polkadot/util-crypto": "^10.1.14",
+        "rxjs": "^7.5.7"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@polkadot/types-augment": {
-      "version": "8.12.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/types-augment/-/types-augment-8.12.2.tgz",
-      "integrity": "sha512-47+T12u7HV+g22KryirG7fik5lU1tHgu39wLv8YZ/6jD1hVvgE632fvaCp4qje1F3M82aXobfekO+WOPLCZVsg==",
+      "version": "9.9.4",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-augment/-/types-augment-9.9.4.tgz",
+      "integrity": "sha512-mQNc0kxt3zM6SC+5hJbsg03fxEFpn5nakki+loE2mNsWr1g+rR7LECagAZ4wT2gvdbzWuY/LlRYyDQxe0PwdZg==",
       "dependencies": {
-        "@babel/runtime": "^7.18.6",
-        "@polkadot/types": "8.12.2",
-        "@polkadot/types-codec": "8.12.2",
-        "@polkadot/util": "^10.0.2"
+        "@babel/runtime": "^7.20.1",
+        "@polkadot/types": "9.9.4",
+        "@polkadot/types-codec": "9.9.4",
+        "@polkadot/util": "^10.1.14"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@polkadot/types-codec": {
-      "version": "8.12.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/types-codec/-/types-codec-8.12.2.tgz",
-      "integrity": "sha512-NDa2ZJpJMWC9Un3PtvkyJF86M80gLqSmPyjIR8xxp0DzcD5EsCL8EV79xcOWUGm2lws1C66a4t4He/8ZwPNUqg==",
+      "version": "9.9.4",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-codec/-/types-codec-9.9.4.tgz",
+      "integrity": "sha512-uSHoQQcj4813c9zNkDDH897K6JB0OznTrH5WeZ1wxpjML7lkuTJ2t/GQE9e4q5Ycl7YePZsvEp2qlc3GwrVm/w==",
       "dependencies": {
-        "@babel/runtime": "^7.18.6",
-        "@polkadot/util": "^10.0.2",
-        "@polkadot/x-bigint": "^10.0.2"
+        "@babel/runtime": "^7.20.1",
+        "@polkadot/util": "^10.1.14",
+        "@polkadot/x-bigint": "^10.1.14"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@polkadot/types-create": {
-      "version": "8.12.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/types-create/-/types-create-8.12.2.tgz",
-      "integrity": "sha512-D+Sfj+TwvipO+wl4XbsVkw5AgFdpy5O2JY88CV6L26EGU2OqCcTuenwSGdrsiLWW65m97q9lP7SUphUh39vBhA==",
+      "version": "9.9.4",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-create/-/types-create-9.9.4.tgz",
+      "integrity": "sha512-EOxLryRQ4JVRSRnIMXk3Tjry1tyegNuWK8OUj51A1wHrX76DF9chME27bXUP4d7el1pjqPuQ9/l+/928GG386g==",
       "dependencies": {
-        "@babel/runtime": "^7.18.6",
-        "@polkadot/types-codec": "8.12.2",
-        "@polkadot/util": "^10.0.2"
+        "@babel/runtime": "^7.20.1",
+        "@polkadot/types-codec": "9.9.4",
+        "@polkadot/util": "^10.1.14"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@polkadot/types-known": {
-      "version": "8.12.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/types-known/-/types-known-8.12.2.tgz",
-      "integrity": "sha512-8HCZ3AkczBrCl+TUZD0+2ubLr0BQx+0f/Nnl9yuz1pWygmSEpHrYspmFtDdpMJnNTGZo8vHNOa7smdlijJqlhw==",
+      "version": "9.9.4",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-known/-/types-known-9.9.4.tgz",
+      "integrity": "sha512-BaKXkg3yZLDv31g0CZPJsZDXX01VTjkQ0tmW9U6fmccEq3zHlxbUiXf3aKlwKRJyDWiEOxr4cQ4GT8jj6uEIuA==",
       "dependencies": {
-        "@babel/runtime": "^7.18.6",
-        "@polkadot/networks": "^10.0.2",
-        "@polkadot/types": "8.12.2",
-        "@polkadot/types-codec": "8.12.2",
-        "@polkadot/types-create": "8.12.2",
-        "@polkadot/util": "^10.0.2"
+        "@babel/runtime": "^7.20.1",
+        "@polkadot/networks": "^10.1.14",
+        "@polkadot/types": "9.9.4",
+        "@polkadot/types-codec": "9.9.4",
+        "@polkadot/types-create": "9.9.4",
+        "@polkadot/util": "^10.1.14"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@polkadot/types-support": {
-      "version": "8.12.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/types-support/-/types-support-8.12.2.tgz",
-      "integrity": "sha512-tTksJ4COcVonu/beWQKkF/6fKaArmTwM6iCuxn2PuJziS2Cm1+7D8Rh3ODwwZOseFvHPEco6jnb4DWNclXbZiA==",
+      "version": "9.9.4",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-support/-/types-support-9.9.4.tgz",
+      "integrity": "sha512-vjhdD7B5kdTLhm2iO0QAb7fM4D2ojNUVVocOJotC9NULYtoC+PkPvkvFbw7VQ1H3u7yxyZfWloMtBnCsIp5EAA==",
       "dependencies": {
-        "@babel/runtime": "^7.18.6",
-        "@polkadot/util": "^10.0.2"
+        "@babel/runtime": "^7.20.1",
+        "@polkadot/util": "^10.1.14"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@polkadot/util": {
-      "version": "10.0.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-10.0.2.tgz",
-      "integrity": "sha512-jE1b6Zzltsb/GJV5sFmTSQOlYLd3fipY+DeLS9J+BbsWZW6uUc5x+FNm4pLrYxF1IqiZxwBv1Vi89L14uWZ1rw==",
+      "version": "10.1.14",
+      "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-10.1.14.tgz",
+      "integrity": "sha512-DX8IUd3j+S4HJBs73gz5d7Z592aW5vn/aD7hzFUlBduQIYBy+L1KIoGchpD6hSSOs5HSy7owePmBlp1lPjUZBg==",
       "dependencies": {
-        "@babel/runtime": "^7.18.6",
-        "@polkadot/x-bigint": "10.0.2",
-        "@polkadot/x-global": "10.0.2",
-        "@polkadot/x-textdecoder": "10.0.2",
-        "@polkadot/x-textencoder": "10.0.2",
-        "@types/bn.js": "^5.1.0",
+        "@babel/runtime": "^7.20.1",
+        "@polkadot/x-bigint": "10.1.14",
+        "@polkadot/x-global": "10.1.14",
+        "@polkadot/x-textdecoder": "10.1.14",
+        "@polkadot/x-textencoder": "10.1.14",
+        "@types/bn.js": "^5.1.1",
         "bn.js": "^5.2.1"
       },
       "engines": {
@@ -1157,18 +1145,18 @@
       }
     },
     "node_modules/@polkadot/util-crypto": {
-      "version": "10.0.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/util-crypto/-/util-crypto-10.0.2.tgz",
-      "integrity": "sha512-0uJFvu5cpRBep0/AcpA8vnXH3gnoe+ADiMKD93AekjxrOVqlrjVHKIf+FbiGv1paRKISxoO5Q2j7nCvDsi1q5w==",
+      "version": "10.1.14",
+      "resolved": "https://registry.npmjs.org/@polkadot/util-crypto/-/util-crypto-10.1.14.tgz",
+      "integrity": "sha512-Iq9C0Snv+pScZ9QgJoH7l++x9wdp9vhS3NMLm8ZqlDCNXUUl/3ViafZCfHRILQD9AsLcykE99mNzFDl3u8jZQA==",
       "dependencies": {
-        "@babel/runtime": "^7.18.6",
-        "@noble/hashes": "1.1.2",
-        "@noble/secp256k1": "1.6.0",
-        "@polkadot/networks": "10.0.2",
-        "@polkadot/util": "10.0.2",
-        "@polkadot/wasm-crypto": "^6.2.3",
-        "@polkadot/x-bigint": "10.0.2",
-        "@polkadot/x-randomvalues": "10.0.2",
+        "@babel/runtime": "^7.20.1",
+        "@noble/hashes": "1.1.3",
+        "@noble/secp256k1": "1.7.0",
+        "@polkadot/networks": "10.1.14",
+        "@polkadot/util": "10.1.14",
+        "@polkadot/wasm-crypto": "^6.3.1",
+        "@polkadot/x-bigint": "10.1.14",
+        "@polkadot/x-randomvalues": "10.1.14",
         "@scure/base": "1.1.1",
         "ed2curve": "^0.3.0",
         "tweetnacl": "^1.0.3"
@@ -1177,15 +1165,15 @@
         "node": ">=14.0.0"
       },
       "peerDependencies": {
-        "@polkadot/util": "10.0.2"
+        "@polkadot/util": "10.1.14"
       }
     },
     "node_modules/@polkadot/wasm-bridge": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/wasm-bridge/-/wasm-bridge-6.2.3.tgz",
-      "integrity": "sha512-kDPcUF5uCZJeJUlWtjk6u4KRy+RTObZbIMgZKiuCcQn9n3EYWadONvStfIyKaiFCc3VFVivzH1cUwTFxxTNHHQ==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/wasm-bridge/-/wasm-bridge-6.3.1.tgz",
+      "integrity": "sha512-1TYkHsb9AEFhU9uZj3biEnN2yKQNzdrwSjiTvfCYnt97pnEkKsZI6cku+YPZQv5w/x9CQa5Yua9e2DVVZSivGA==",
       "dependencies": {
-        "@babel/runtime": "^7.18.6"
+        "@babel/runtime": "^7.18.9"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -1196,16 +1184,16 @@
       }
     },
     "node_modules/@polkadot/wasm-crypto": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto/-/wasm-crypto-6.2.3.tgz",
-      "integrity": "sha512-Jq08uX16YYySanwN/37n/ZzOFv8T2H4NzLaQNjSGNbFdmKzkrlpw369XRNIVhrKGtK4v09O5ZaF5P9qc0EHgsg==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto/-/wasm-crypto-6.3.1.tgz",
+      "integrity": "sha512-OO8h0qeVkqp4xYZaRVl4iuWOEtq282pNBHDKb6SOJuI2g59eWGcKh4EQU9Me2VP6qzojIqptrkrVt7KQXC68gA==",
       "dependencies": {
-        "@babel/runtime": "^7.18.6",
-        "@polkadot/wasm-bridge": "6.2.3",
-        "@polkadot/wasm-crypto-asmjs": "6.2.3",
-        "@polkadot/wasm-crypto-init": "6.2.3",
-        "@polkadot/wasm-crypto-wasm": "6.2.3",
-        "@polkadot/wasm-util": "6.2.3"
+        "@babel/runtime": "^7.18.9",
+        "@polkadot/wasm-bridge": "6.3.1",
+        "@polkadot/wasm-crypto-asmjs": "6.3.1",
+        "@polkadot/wasm-crypto-init": "6.3.1",
+        "@polkadot/wasm-crypto-wasm": "6.3.1",
+        "@polkadot/wasm-util": "6.3.1"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -1216,11 +1204,11 @@
       }
     },
     "node_modules/@polkadot/wasm-crypto-asmjs": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto-asmjs/-/wasm-crypto-asmjs-6.2.3.tgz",
-      "integrity": "sha512-d/eH02d/XB/vIGIQwyoFB4zNRb3h5PlWoXolGeVSuoa8476ouEdaWhy64mFwXBmjfluaeCOFXRs+QbxetwrDZg==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto-asmjs/-/wasm-crypto-asmjs-6.3.1.tgz",
+      "integrity": "sha512-zbombRfA5v/mUWQQhgg2YwaxhRmxRIrvskw65x+lruax3b6xPBFDs7yplopiJU3r8h2pTgQvX/DUksvqz2TCRQ==",
       "dependencies": {
-        "@babel/runtime": "^7.18.6"
+        "@babel/runtime": "^7.18.9"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -1230,14 +1218,14 @@
       }
     },
     "node_modules/@polkadot/wasm-crypto-init": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto-init/-/wasm-crypto-init-6.2.3.tgz",
-      "integrity": "sha512-jDFD4ITWbvFgsGiRI61lrzI/eobG8VrI9nVCiDBqQZK7mNnGkyIdnFD1prW36uiv6/tkqSiGGvdb7dEKtmsB+Q==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto-init/-/wasm-crypto-init-6.3.1.tgz",
+      "integrity": "sha512-9yaUBcu+snwjJLmPPGl3cyGRQ1afyFGm16qzTM0sgG/ZCfUlK4uk8KWZe+sBUKgoxb2oXY7Y4WklKgQI1YBdfw==",
       "dependencies": {
-        "@babel/runtime": "^7.18.6",
-        "@polkadot/wasm-bridge": "6.2.3",
-        "@polkadot/wasm-crypto-asmjs": "6.2.3",
-        "@polkadot/wasm-crypto-wasm": "6.2.3"
+        "@babel/runtime": "^7.18.9",
+        "@polkadot/wasm-bridge": "6.3.1",
+        "@polkadot/wasm-crypto-asmjs": "6.3.1",
+        "@polkadot/wasm-crypto-wasm": "6.3.1"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -1248,12 +1236,12 @@
       }
     },
     "node_modules/@polkadot/wasm-crypto-wasm": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto-wasm/-/wasm-crypto-wasm-6.2.3.tgz",
-      "integrity": "sha512-bYRhYPcR4MBLAZz8liozr8E11r7j6RLkNHu80z65lZ5AWgjDu2MgYfKxZFWZxg8rB6+V1uYFmb7czUiSWOn4Rg==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto-wasm/-/wasm-crypto-wasm-6.3.1.tgz",
+      "integrity": "sha512-idSlzKGVzCfeCMRHsacRvqwojSaTadFxL/Dbls4z1thvfa3U9Ku0d2qVtlwg7Hj+tYWDiuP8Kygs+6bQwfs0XA==",
       "dependencies": {
-        "@babel/runtime": "^7.18.6",
-        "@polkadot/wasm-util": "6.2.3"
+        "@babel/runtime": "^7.18.9",
+        "@polkadot/wasm-util": "6.3.1"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -1263,11 +1251,11 @@
       }
     },
     "node_modules/@polkadot/wasm-util": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/wasm-util/-/wasm-util-6.2.3.tgz",
-      "integrity": "sha512-8BQ9gVSrjdc0MPWN9qtNWlMiK+J8dICu1gZJ+cy/hqKjer2MzwX4SeW2wyL5MkYYHjih3ajMRSoSA+/eY2iEwg==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/wasm-util/-/wasm-util-6.3.1.tgz",
+      "integrity": "sha512-12oAv5J7Yoc9m6jixrSaQCxpOkWOyzHx3DMC8qmLjRiwdBWxqLmImOVRVnFsbaxqSbhBIHRuJphVxWE+GZETDg==",
       "dependencies": {
-        "@babel/runtime": "^7.18.6"
+        "@babel/runtime": "^7.18.9"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -1277,85 +1265,85 @@
       }
     },
     "node_modules/@polkadot/x-bigint": {
-      "version": "10.0.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-bigint/-/x-bigint-10.0.2.tgz",
-      "integrity": "sha512-LtfPi+AyZDNe8jQGVmyDfxGyQDdM6ISZEwJD1ieGd4eUbOkfPmn+1t+0rjtxjISZcyP40fSFcLxtL191jDV8Bw==",
+      "version": "10.1.14",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-bigint/-/x-bigint-10.1.14.tgz",
+      "integrity": "sha512-HgrofhI+WM699ozJ9zFZcPUApB2jqwCEOMUgM1jv2WNxF0ILKNDpH08dB8OBy2SKfnKoSgmXwWtxWl1u+mq10A==",
       "dependencies": {
-        "@babel/runtime": "^7.18.6",
-        "@polkadot/x-global": "10.0.2"
+        "@babel/runtime": "^7.20.1",
+        "@polkadot/x-global": "10.1.14"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@polkadot/x-fetch": {
-      "version": "10.0.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-fetch/-/x-fetch-10.0.2.tgz",
-      "integrity": "sha512-vsizrcBNeRWWJhE4ZoCUJ0c68wvy3PiR9jH//B1PTV6OaqpdalpwXG6Xtpli8yc0hOOUH/87u8b/x2f/2vhZcQ==",
+      "version": "10.1.14",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-fetch/-/x-fetch-10.1.14.tgz",
+      "integrity": "sha512-07H9unwv0tT5RQRkj1WE67ug6x6RlUfGN/mJWSKqf0JjsfQlPMKDC9yZW1oUSsasBUyIf0qbspuVSyhZu+0cpg==",
       "dependencies": {
-        "@babel/runtime": "^7.18.6",
-        "@polkadot/x-global": "10.0.2",
+        "@babel/runtime": "^7.20.1",
+        "@polkadot/x-global": "10.1.14",
         "@types/node-fetch": "^2.6.2",
-        "node-fetch": "^3.2.6"
+        "node-fetch": "^3.3.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@polkadot/x-global": {
-      "version": "10.0.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-10.0.2.tgz",
-      "integrity": "sha512-IlxSH36RjcQTImufaJCtvommMmkNWbwOy+/Z7FEOKUOcoiPaUhHU3CzWser+EtClckx7qPLY5lZ59Pxf7HWupQ==",
+      "version": "10.1.14",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-10.1.14.tgz",
+      "integrity": "sha512-ye3Yx2bfIoHf5t78rbDad587J16JanrcfpGSWoknWOZ7wmatj/CJKWhJ/VKMPfJGEJm2LidH1B0W8QDfrMEmTA==",
       "dependencies": {
-        "@babel/runtime": "^7.18.6"
+        "@babel/runtime": "^7.20.1"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@polkadot/x-randomvalues": {
-      "version": "10.0.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-randomvalues/-/x-randomvalues-10.0.2.tgz",
-      "integrity": "sha512-kYbNeeOaDEnNqVhIgh8ds9YC79Tji5/HDqQymx7Xb3YmTagdOAe2klrTRJzVfsUKljzhlVOuF3Zcf/PRNbt/2w==",
+      "version": "10.1.14",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-randomvalues/-/x-randomvalues-10.1.14.tgz",
+      "integrity": "sha512-mrZho4qogLZmox7wuP1XF03HTZ4CwAjzV7RvKmwH8ToNCR6E4NRo2btgG67Z0K+bUOQRbXWL2hQazusa2p2N6w==",
       "dependencies": {
-        "@babel/runtime": "^7.18.6",
-        "@polkadot/x-global": "10.0.2"
+        "@babel/runtime": "^7.20.1",
+        "@polkadot/x-global": "10.1.14"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@polkadot/x-textdecoder": {
-      "version": "10.0.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-10.0.2.tgz",
-      "integrity": "sha512-EI1+Osrfadtm4XFfdcjYgV/1yYoPoFaIJfZiPphPSy/4Ceeblmz9T2hWPdJ3uWtPpk6FkhxudB44Y1JuCwXBjg==",
+      "version": "10.1.14",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-10.1.14.tgz",
+      "integrity": "sha512-qwbeR8v6a5Z9MdbjzcY5gFiRWbp8bBVoDEf1Dd+yH9/UAyFXodlMKs3irDdVhGVPCbZWQTVDEZRUgEqRxwKC7w==",
       "dependencies": {
-        "@babel/runtime": "^7.18.6",
-        "@polkadot/x-global": "10.0.2"
+        "@babel/runtime": "^7.20.1",
+        "@polkadot/x-global": "10.1.14"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@polkadot/x-textencoder": {
-      "version": "10.0.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-10.0.2.tgz",
-      "integrity": "sha512-iTLC700ExtRFsP+fE+dA5CO0xjQ46XeQqbJxa7wJK3aKrzpogyTLZXc0O5ISE1xltOmsQSA9QOELMP113kZkvA==",
+      "version": "10.1.14",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-10.1.14.tgz",
+      "integrity": "sha512-MC30rtQiFVgQDSP8wO5wa1so5tW3T7qs/DCT018A4zgjiK+uFdIGOerAgoxcNw3yC6IGnPIL5lsRO/1C9N60zA==",
       "dependencies": {
-        "@babel/runtime": "^7.18.6",
-        "@polkadot/x-global": "10.0.2"
+        "@babel/runtime": "^7.20.1",
+        "@polkadot/x-global": "10.1.14"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@polkadot/x-ws": {
-      "version": "10.0.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-ws/-/x-ws-10.0.2.tgz",
-      "integrity": "sha512-eH8WJ6jKobfUGLRAGj65wKUB2pwbT7RflebQbbcG8Khx9INRjuwLGc+jAiuf0StOZiqVVJsMUayVgsddO8hIvQ==",
+      "version": "10.1.14",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-ws/-/x-ws-10.1.14.tgz",
+      "integrity": "sha512-xgyMYR34sHxKCtQUJ2btFAyN3fK1OqCqvAyRYmU52801aguLstRhVPAZxXJp3Dahs91FX/h/ZZzmwXD01tJtyA==",
       "dependencies": {
-        "@babel/runtime": "^7.18.6",
-        "@polkadot/x-global": "10.0.2",
+        "@babel/runtime": "^7.20.1",
+        "@polkadot/x-global": "10.1.14",
         "@types/websocket": "^1.0.5",
         "websocket": "^1.0.34"
       },
@@ -1375,39 +1363,38 @@
       ]
     },
     "node_modules/@substrate/connect": {
-      "version": "0.7.7",
-      "resolved": "https://registry.npmjs.org/@substrate/connect/-/connect-0.7.7.tgz",
-      "integrity": "sha512-uFRF06lC42ZZixxwkzRB61K1uYvR1cTZ7rI98RW7T+eWbCFrafyVk0pk6J+4oN05gZkhou+VK3hrRCU6Doy2xQ==",
+      "version": "0.7.17",
+      "resolved": "https://registry.npmjs.org/@substrate/connect/-/connect-0.7.17.tgz",
+      "integrity": "sha512-s0XBmGpUCFWZFa+TS0TEvOKtWjJP2uT4xKmvzApH8INB5xbz79wqWFX6WWh3AlK/X1P0Smt+RVEH7HQiLJAYAw==",
       "dependencies": {
-        "@substrate/connect-extension-protocol": "^1.0.0",
-        "@substrate/smoldot-light": "0.6.19",
+        "@substrate/connect-extension-protocol": "^1.0.1",
+        "@substrate/smoldot-light": "0.7.7",
         "eventemitter3": "^4.0.7"
       }
     },
     "node_modules/@substrate/connect-extension-protocol": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@substrate/connect-extension-protocol/-/connect-extension-protocol-1.0.0.tgz",
-      "integrity": "sha512-nFVuKdp71hMd/MGlllAOh+a2hAqt8m6J2G0aSsS/RcALZexxF9jodbFc62ni8RDtJboeOfXAHhenYOANvJKPIg=="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@substrate/connect-extension-protocol/-/connect-extension-protocol-1.0.1.tgz",
+      "integrity": "sha512-161JhCC1csjH3GE5mPLEd7HbWtwNSPJBg3p1Ksz9SFlTzj/bgEwudiRN2y5i0MoLGCIJRYKyKGMxVnd29PzNjg=="
     },
     "node_modules/@substrate/smoldot-light": {
-      "version": "0.6.19",
-      "resolved": "https://registry.npmjs.org/@substrate/smoldot-light/-/smoldot-light-0.6.19.tgz",
-      "integrity": "sha512-Xi+v1cdURhTwx7NH+9fa1U9m7VGP61GvB6qwev9HrZXlGbQiUIvySxPlH/LMsq3mwgiRYkokPhcaZEHufY7Urg==",
+      "version": "0.7.7",
+      "resolved": "https://registry.npmjs.org/@substrate/smoldot-light/-/smoldot-light-0.7.7.tgz",
+      "integrity": "sha512-ksxeAed6dIUtYSl0f8ehgWQjwXnpDGTIJt+WVRIGt3OObZkA96ZdBWx0xP7GrXZtj37u4n/Y1z7TyTm4bwQvrw==",
       "dependencies": {
-        "buffer": "^6.0.1",
         "pako": "^2.0.4",
-        "websocket": "^1.0.32"
+        "ws": "^8.8.1"
       }
     },
     "node_modules/@substrate/ss58-registry": {
-      "version": "1.23.0",
-      "resolved": "https://registry.npmjs.org/@substrate/ss58-registry/-/ss58-registry-1.23.0.tgz",
-      "integrity": "sha512-LuQje7n48GXSsp1aGI6UEmNVtlh7OzQ6CN1Hd9VGUrshADwMB0lRZ5bxnffmqDR4vVugI7h0NN0AONhIW1eHGg=="
+      "version": "1.35.0",
+      "resolved": "https://registry.npmjs.org/@substrate/ss58-registry/-/ss58-registry-1.35.0.tgz",
+      "integrity": "sha512-cIY3J7RlT4mfPNFwd2mv1q9vTp/shImw2gN2y2outMhOcagH/HG+W8/JohpifjxPC/1pbQ0Z8nxfL5Td3EchcA=="
     },
     "node_modules/@types/bn.js": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-5.1.0.tgz",
-      "integrity": "sha512-QSSVYj7pYFN49kW77o2s9xTCwZ8F2xLbjLLSEVh8D2F4JUhZtPAGOFLTD+ffqksBx/u4cE/KImFjyhqCjn/LIA==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-5.1.1.tgz",
+      "integrity": "sha512-qNrYbZqMx0uJAfKnKclPh+dTwK33KfLHYqtyODwd5HnXOjnkhc4qgn3BrK6RWyGZm5+sIFE7Q7Vz6QQtJB7w7g==",
       "dependencies": {
         "@types/node": "*"
       }
@@ -2037,9 +2024,9 @@
       }
     },
     "node_modules/bufferutil": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.0.6.tgz",
-      "integrity": "sha512-jduaYOYtnio4aIAyc6UbvPCVcgq7nYpVnucyxr6eCYg/Woad9Hf/oxxBRDnGGjPfjUm6j5O/uBWhIu4iLebFaw==",
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.0.7.tgz",
+      "integrity": "sha512-kukuqc39WOHtdxtw4UScxF/WVnMFVSQVKhtx3AjZJzhd0RGZZldcrfSEbVsWWe6KNH253574cq5F+wpv0G9pJw==",
       "hasInstallScript": true,
       "dependencies": {
         "node-gyp-build": "^4.3.0"
@@ -2739,9 +2726,9 @@
       }
     },
     "node_modules/es5-ext": {
-      "version": "0.10.61",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.61.tgz",
-      "integrity": "sha512-yFhIqQAzu2Ca2I4SE2Au3rxVfmohU9Y7wqGR+s7+H7krk26NXhIRAZDgqd6xqjCEFUomDEA3/Bo/7fKmIkW1kA==",
+      "version": "0.10.62",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.62.tgz",
+      "integrity": "sha512-BHLqn0klhEpnOKSrzn/Xsz2UIW8j+cGmo9JLzr8BiUapV8hPL9+FliFqjwr9ngW7jWdnxv6eO+/LqyhJVqgrjA==",
       "hasInstallScript": true,
       "dependencies": {
         "es6-iterator": "^2.0.3",
@@ -3303,17 +3290,17 @@
       ]
     },
     "node_modules/ext": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/ext/-/ext-1.6.0.tgz",
-      "integrity": "sha512-sdBImtzkq2HpkdRLtlLWDa6w4DX22ijZLKx8BMPUuKe1c5lbN6xwQDQCxSfxBQnHZ13ls/FH0MQZx/q/gr6FQg==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/ext/-/ext-1.7.0.tgz",
+      "integrity": "sha512-6hxeJYaL110a9b5TEJSj0gojyHQAmA2ch5Os+ySCiA1QGdS697XWY1pzsrSjqA9LDEEgdB/KypIlR59RcLuHYw==",
       "dependencies": {
-        "type": "^2.5.0"
+        "type": "^2.7.2"
       }
     },
     "node_modules/ext/node_modules/type": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/type/-/type-2.6.0.tgz",
-      "integrity": "sha512-eiDBDOmkih5pMbo9OqsqPRGMljLodLcwd5XD5JbtNB0o89xZAwynY9EdCDsJU7LtcVCClu9DvM7/0Ep1hYX3EQ=="
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/type/-/type-2.7.2.tgz",
+      "integrity": "sha512-dzlvlNlt6AXU7EBSfpAscydQ7gXB+pPGsPnfJnZpiNJBDj7IaJzQlBZYGdEi4R9HmPdBv2XmWJ6YUtoTa7lmCw=="
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -5141,9 +5128,9 @@
       }
     },
     "node_modules/node-fetch": {
-      "version": "3.2.10",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.2.10.tgz",
-      "integrity": "sha512-MhuzNwdURnZ1Cp4XTazr69K0BTizsBroX7Zx3UgDSVcZYKF/6p0CBe4EUb/hLqmzVhl0UpYfgRljQ4yxE+iCxA==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.0.tgz",
+      "integrity": "sha512-BKwRP/O0UvoMKp7GNdwPlObhYGB5DQqwhEDQlNKuoqwVYSxkSZCSbHjnFFmUEtwSKRPU4kNK8PbDYYitwaE3QA==",
       "dependencies": {
         "data-uri-to-buffer": "^4.0.0",
         "fetch-blob": "^3.1.4",
@@ -5777,9 +5764,9 @@
       "integrity": "sha512-HAKu/fG3HpHFO0AA8WE8q2g+gBJaZ9MG7fcKk+IJPLTGAD6Psw4443l+9DGRbOIh3/aXr7Phy0TjilYivJo5XQ=="
     },
     "node_modules/pako": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/pako/-/pako-2.0.4.tgz",
-      "integrity": "sha512-v8tweI900AUkZN6heMU/4Uy4cXRc2AYNRggVmTR+dEncawDJgCdLMximOVA2p4qO57WMynangsfGRb5WD6L1Bg=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
+      "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug=="
     },
     "node_modules/parent-module": {
       "version": "1.0.1",
@@ -6513,9 +6500,9 @@
       }
     },
     "node_modules/regenerator-runtime": {
-      "version": "0.13.9",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
-      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA=="
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
     },
     "node_modules/regexpp": {
       "version": "3.2.0",
@@ -6644,9 +6631,9 @@
       }
     },
     "node_modules/rxjs": {
-      "version": "7.5.6",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.6.tgz",
-      "integrity": "sha512-dnyv2/YsXhnm461G+R/Pe5bWP41Nm6LBXEYWI6eiFP4fiwx6WRI/CD0zbdVAudd9xwLEF2IDcKXLHit0FYjUzw==",
+      "version": "7.5.7",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.7.tgz",
+      "integrity": "sha512-z9MzKh/UcOqB3i20H6rtrlaE/CgjLOvheWK/9ILrbhROGTweAi1BaFsTT9FbwZi5Trr1qNRs+MXkhmR06awzQA==",
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -7335,9 +7322,9 @@
       }
     },
     "node_modules/utf-8-validate": {
-      "version": "5.0.9",
-      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.9.tgz",
-      "integrity": "sha512-Yek7dAy0v3Kl0orwMlvi7TPtiCNrdfHNd7Gcc/pLq4BLXqfAmd0J7OWMizUQnTTJsyjKn02mU7anqwfmUP4J8Q==",
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
+      "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
       "hasInstallScript": true,
       "dependencies": {
         "node-gyp-build": "^4.3.0"
@@ -7503,6 +7490,26 @@
         "is-typedarray": "^1.0.0",
         "signal-exit": "^3.0.2",
         "typedarray-to-buffer": "^3.1.5"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
+      "integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/xtend": {
@@ -7871,11 +7878,11 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.18.6.tgz",
-      "integrity": "sha512-t9wi7/AW6XtKahAe20Yw0/mMljKq0B1r2fPdvaAdV/KPDZewFXdaaa6K7lxmZBZ8FBNpCiAT6iHPmd6QO9bKfQ==",
+      "version": "7.20.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.20.6.tgz",
+      "integrity": "sha512-Q+8MqP7TiHMWzSfwiJwXCjyf4GYA4Dgw3emg/7xmwsdLJOZUp+nMqcOwOzzYheuM1rhDu8FSj2l0aoMygEuXuA==",
       "requires": {
-        "regenerator-runtime": "^0.13.4"
+        "regenerator-runtime": "^0.13.11"
       }
     },
     "@babel/template": {
@@ -7946,14 +7953,6 @@
       "requires": {
         "@babel/helper-validator-identifier": "^7.16.7",
         "to-fast-properties": "^2.0.0"
-      }
-    },
-    "@digicatapult/dscp-node": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@digicatapult/dscp-node/-/dscp-node-4.3.1.tgz",
-      "integrity": "sha512-RszD9z93VXIIK3w4Y3dnREZvsVXVtV/8fjAcHuaGornYZRH88vFoWIBfU+HD+DaK1QvJXUr51guDTfXPVuD4kw==",
-      "requires": {
-        "@polkadot/api": "^8.11.3"
       }
     },
     "@eslint/eslintrc": {
@@ -8180,14 +8179,14 @@
       }
     },
     "@noble/hashes": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.1.2.tgz",
-      "integrity": "sha512-KYRCASVTv6aeUi1tsF8/vpyR7zpfs3FUzy2Jqm+MU+LmUKhQ0y2FpfwqkCcxSg2ua4GALJd8k2R76WxwZGbQpA=="
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.1.3.tgz",
+      "integrity": "sha512-CE0FCR57H2acVI5UOzIGSSIYxZ6v/HOhDR0Ro9VLyhnzLwx0o8W1mmgaqlEUx4049qJDlIBRztv5k+MM8vbO3A=="
     },
     "@noble/secp256k1": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-1.6.0.tgz",
-      "integrity": "sha512-DWSsg8zMHOYMYBqIQi96BQuthZrp98LCeMNcUOaffCIVYQ5yxDbNikLF+H7jEnmNNmXbtVic46iCuVWzar+MgA=="
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-1.7.0.tgz",
+      "integrity": "sha512-kbacwGSsH/CTout0ZnZWxnW1B+jH/7r/WAAKLBtrRJ/+CUH7lgmQzl3GTrQua3SGKWNSDsS6lmjnDpIJ5Dxyaw=="
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -8221,356 +8220,356 @@
       "integrity": "sha512-UdkG3mLEqXgnlKsWanWcgb6dOjUzJ+XC5f+aWw30qrtjxeNUSfKX1cd5FBzOaXQumoe9nIqeZUvrRJS03HCCtw=="
     },
     "@polkadot/api": {
-      "version": "8.12.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/api/-/api-8.12.2.tgz",
-      "integrity": "sha512-bK3bhCFqCYTx/K/89QF88jYqE3Dc1LmCwMnwpof6adlAj5DoEjRfSmKarqrZqox516Xph1+84ACNkyem0KnIWA==",
+      "version": "9.9.4",
+      "resolved": "https://registry.npmjs.org/@polkadot/api/-/api-9.9.4.tgz",
+      "integrity": "sha512-ze7W/DXsPHsixrFOACzugDQqezzrUGGX1Z2JOl6z+V8pd+ZKLSecsKJFUzf4yoBT82ArITYPtRVx/Dq9b9K2dA==",
       "requires": {
-        "@babel/runtime": "^7.18.6",
-        "@polkadot/api-augment": "8.12.2",
-        "@polkadot/api-base": "8.12.2",
-        "@polkadot/api-derive": "8.12.2",
-        "@polkadot/keyring": "^10.0.2",
-        "@polkadot/rpc-augment": "8.12.2",
-        "@polkadot/rpc-core": "8.12.2",
-        "@polkadot/rpc-provider": "8.12.2",
-        "@polkadot/types": "8.12.2",
-        "@polkadot/types-augment": "8.12.2",
-        "@polkadot/types-codec": "8.12.2",
-        "@polkadot/types-create": "8.12.2",
-        "@polkadot/types-known": "8.12.2",
-        "@polkadot/util": "^10.0.2",
-        "@polkadot/util-crypto": "^10.0.2",
+        "@babel/runtime": "^7.20.1",
+        "@polkadot/api-augment": "9.9.4",
+        "@polkadot/api-base": "9.9.4",
+        "@polkadot/api-derive": "9.9.4",
+        "@polkadot/keyring": "^10.1.14",
+        "@polkadot/rpc-augment": "9.9.4",
+        "@polkadot/rpc-core": "9.9.4",
+        "@polkadot/rpc-provider": "9.9.4",
+        "@polkadot/types": "9.9.4",
+        "@polkadot/types-augment": "9.9.4",
+        "@polkadot/types-codec": "9.9.4",
+        "@polkadot/types-create": "9.9.4",
+        "@polkadot/types-known": "9.9.4",
+        "@polkadot/util": "^10.1.14",
+        "@polkadot/util-crypto": "^10.1.14",
         "eventemitter3": "^4.0.7",
-        "rxjs": "^7.5.5"
+        "rxjs": "^7.5.7"
       }
     },
     "@polkadot/api-augment": {
-      "version": "8.12.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/api-augment/-/api-augment-8.12.2.tgz",
-      "integrity": "sha512-HbvNOu6ntago8nYqLkq/HZ+gsMhbKe/sD4hPIFPruhP6OAnW6TWNIlqc2ruFx2KrT0rfzXUZ4Gmk4WgyRFuz4Q==",
+      "version": "9.9.4",
+      "resolved": "https://registry.npmjs.org/@polkadot/api-augment/-/api-augment-9.9.4.tgz",
+      "integrity": "sha512-+T9YWw5kEi7AkSoS2UfE1nrVeJUtD92elQBZ3bMMkfM1geKWhSnvBLyTMn6kFmNXTfK0qt8YKS1pwbux7cC9tg==",
       "requires": {
-        "@babel/runtime": "^7.18.6",
-        "@polkadot/api-base": "8.12.2",
-        "@polkadot/rpc-augment": "8.12.2",
-        "@polkadot/types": "8.12.2",
-        "@polkadot/types-augment": "8.12.2",
-        "@polkadot/types-codec": "8.12.2",
-        "@polkadot/util": "^10.0.2"
+        "@babel/runtime": "^7.20.1",
+        "@polkadot/api-base": "9.9.4",
+        "@polkadot/rpc-augment": "9.9.4",
+        "@polkadot/types": "9.9.4",
+        "@polkadot/types-augment": "9.9.4",
+        "@polkadot/types-codec": "9.9.4",
+        "@polkadot/util": "^10.1.14"
       }
     },
     "@polkadot/api-base": {
-      "version": "8.12.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/api-base/-/api-base-8.12.2.tgz",
-      "integrity": "sha512-5rLOCulXNU/g0rUVoW6ArQjOBq/07S6oKR9nOJls6W4PUhYcBIClCTlXx2uoDszMdwhEhYyHQ67bnoTcRrYcLA==",
+      "version": "9.9.4",
+      "resolved": "https://registry.npmjs.org/@polkadot/api-base/-/api-base-9.9.4.tgz",
+      "integrity": "sha512-G1DcxcMeGcvaAAA3u5Tbf70zE5aIuAPEAXnptFMF0lvJz4O6CM8k8ZZFTSk25hjsYlnx8WI1FTc97q4/tKie+Q==",
       "requires": {
-        "@babel/runtime": "^7.18.6",
-        "@polkadot/rpc-core": "8.12.2",
-        "@polkadot/types": "8.12.2",
-        "@polkadot/util": "^10.0.2",
-        "rxjs": "^7.5.5"
+        "@babel/runtime": "^7.20.1",
+        "@polkadot/rpc-core": "9.9.4",
+        "@polkadot/types": "9.9.4",
+        "@polkadot/util": "^10.1.14",
+        "rxjs": "^7.5.7"
       }
     },
     "@polkadot/api-derive": {
-      "version": "8.12.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/api-derive/-/api-derive-8.12.2.tgz",
-      "integrity": "sha512-F7HCAVNXLQphv7OYVcq7GM5CP6RzGvYfTqutmc5GZFCDVMDY9RQA+a/3T5BIjJXrtepPa0pcYvt9fcovsazhZw==",
+      "version": "9.9.4",
+      "resolved": "https://registry.npmjs.org/@polkadot/api-derive/-/api-derive-9.9.4.tgz",
+      "integrity": "sha512-3ka7GzY4QbI3d/DHjQ9SjfDOTDxeU8gM2Dn31BP1oFzGwdFe2GZhDIE//lR5S6UDVxNNlgWz4927AunOQcuAmg==",
       "requires": {
-        "@babel/runtime": "^7.18.6",
-        "@polkadot/api": "8.12.2",
-        "@polkadot/api-augment": "8.12.2",
-        "@polkadot/api-base": "8.12.2",
-        "@polkadot/rpc-core": "8.12.2",
-        "@polkadot/types": "8.12.2",
-        "@polkadot/types-codec": "8.12.2",
-        "@polkadot/util": "^10.0.2",
-        "@polkadot/util-crypto": "^10.0.2",
-        "rxjs": "^7.5.5"
+        "@babel/runtime": "^7.20.1",
+        "@polkadot/api": "9.9.4",
+        "@polkadot/api-augment": "9.9.4",
+        "@polkadot/api-base": "9.9.4",
+        "@polkadot/rpc-core": "9.9.4",
+        "@polkadot/types": "9.9.4",
+        "@polkadot/types-codec": "9.9.4",
+        "@polkadot/util": "^10.1.14",
+        "@polkadot/util-crypto": "^10.1.14",
+        "rxjs": "^7.5.7"
       }
     },
     "@polkadot/keyring": {
-      "version": "10.0.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/keyring/-/keyring-10.0.2.tgz",
-      "integrity": "sha512-N/lx/e9alR/lUREap4hQ/YKa+CKCFIa4QOKLz8eFhpqhbA5M5nQcjrppitO+sX/XlpmbOBpbnO168cU2dA09Iw==",
+      "version": "10.1.14",
+      "resolved": "https://registry.npmjs.org/@polkadot/keyring/-/keyring-10.1.14.tgz",
+      "integrity": "sha512-iejbAfGfdyTB0pixWX6HhWXkUKBHLNy7+Z+F4DU8IwpJE48iOsMRJb3qShbk5NERjx1QIjoOpSZYxiCaF6gd+w==",
       "requires": {
-        "@babel/runtime": "^7.18.6",
-        "@polkadot/util": "10.0.2",
-        "@polkadot/util-crypto": "10.0.2"
+        "@babel/runtime": "^7.20.1",
+        "@polkadot/util": "10.1.14",
+        "@polkadot/util-crypto": "10.1.14"
       }
     },
     "@polkadot/networks": {
-      "version": "10.0.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/networks/-/networks-10.0.2.tgz",
-      "integrity": "sha512-K7hUFmErTrBtkobhvFwT/oPEQrI1oVr7WfngquM+zN0oHiHzRspecxifGKsQ1kw78F7zrZKOBScW/hoJbdI8fA==",
+      "version": "10.1.14",
+      "resolved": "https://registry.npmjs.org/@polkadot/networks/-/networks-10.1.14.tgz",
+      "integrity": "sha512-lo4Y57yBqiad4Z2zBW0r7Ct/iKXNgsTfazDTbHRkIh3RuX36PNYshaX3p7R0eNRuetV1jJv7jqwc1nAMNI2KwQ==",
       "requires": {
-        "@babel/runtime": "^7.18.6",
-        "@polkadot/util": "10.0.2",
-        "@substrate/ss58-registry": "^1.23.0"
+        "@babel/runtime": "^7.20.1",
+        "@polkadot/util": "10.1.14",
+        "@substrate/ss58-registry": "^1.35.0"
       }
     },
     "@polkadot/rpc-augment": {
-      "version": "8.12.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/rpc-augment/-/rpc-augment-8.12.2.tgz",
-      "integrity": "sha512-FKVMmkYhWJNcuXpRN9t7xTX5agSgcgniP8gNPMhL6GV8lV3Xoxs8gLgVy32xeAh7gxArN/my6LnYPtXVkdFALQ==",
+      "version": "9.9.4",
+      "resolved": "https://registry.npmjs.org/@polkadot/rpc-augment/-/rpc-augment-9.9.4.tgz",
+      "integrity": "sha512-67zGQAhJuXd/CZlwDZTgxNt3xGtsDwLvLvyFrHuNjJNM0KGCyt/OpQHVBlyZ6xfII0WZpccASN6P2MxsGTMnKw==",
       "requires": {
-        "@babel/runtime": "^7.18.6",
-        "@polkadot/rpc-core": "8.12.2",
-        "@polkadot/types": "8.12.2",
-        "@polkadot/types-codec": "8.12.2",
-        "@polkadot/util": "^10.0.2"
+        "@babel/runtime": "^7.20.1",
+        "@polkadot/rpc-core": "9.9.4",
+        "@polkadot/types": "9.9.4",
+        "@polkadot/types-codec": "9.9.4",
+        "@polkadot/util": "^10.1.14"
       }
     },
     "@polkadot/rpc-core": {
-      "version": "8.12.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/rpc-core/-/rpc-core-8.12.2.tgz",
-      "integrity": "sha512-RLhzNYJonfsQXYhZuyVBSsOwSgCf+8ijS3aUcv06yrFf26k7nXw2Uc4P0Io3jY/wq5LnvkKzL+HSj6j7XZ+/Sg==",
+      "version": "9.9.4",
+      "resolved": "https://registry.npmjs.org/@polkadot/rpc-core/-/rpc-core-9.9.4.tgz",
+      "integrity": "sha512-DxhJcq1GAi+28nLMqhTksNMqTX40bGNhYuyQyy/to39VxizAjx+lyAHAMfzG9lvPnTIi2KzXif2pCdWq3AgJag==",
       "requires": {
-        "@babel/runtime": "^7.18.6",
-        "@polkadot/rpc-augment": "8.12.2",
-        "@polkadot/rpc-provider": "8.12.2",
-        "@polkadot/types": "8.12.2",
-        "@polkadot/util": "^10.0.2",
-        "rxjs": "^7.5.5"
+        "@babel/runtime": "^7.20.1",
+        "@polkadot/rpc-augment": "9.9.4",
+        "@polkadot/rpc-provider": "9.9.4",
+        "@polkadot/types": "9.9.4",
+        "@polkadot/util": "^10.1.14",
+        "rxjs": "^7.5.7"
       }
     },
     "@polkadot/rpc-provider": {
-      "version": "8.12.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/rpc-provider/-/rpc-provider-8.12.2.tgz",
-      "integrity": "sha512-fgXKAYDmc1kGmOPa2Nuh+LsUBFvUzgzP/tOEbS5UJpoc0+azZfTLWh2AXpo/gVHblR6zZBDWrB3wmGzu6wF17A==",
+      "version": "9.9.4",
+      "resolved": "https://registry.npmjs.org/@polkadot/rpc-provider/-/rpc-provider-9.9.4.tgz",
+      "integrity": "sha512-aUkPtlYukAOFX3FkUgLw3MNy+T0mCiCX7va3PIts9ggK4vl14NFZHurCZq+5ANvknRU4WG8P5teurH9Rd9oDjQ==",
       "requires": {
-        "@babel/runtime": "^7.18.6",
-        "@polkadot/keyring": "^10.0.2",
-        "@polkadot/types": "8.12.2",
-        "@polkadot/types-support": "8.12.2",
-        "@polkadot/util": "^10.0.2",
-        "@polkadot/util-crypto": "^10.0.2",
-        "@polkadot/x-fetch": "^10.0.2",
-        "@polkadot/x-global": "^10.0.2",
-        "@polkadot/x-ws": "^10.0.2",
-        "@substrate/connect": "0.7.7",
+        "@babel/runtime": "^7.20.1",
+        "@polkadot/keyring": "^10.1.14",
+        "@polkadot/types": "9.9.4",
+        "@polkadot/types-support": "9.9.4",
+        "@polkadot/util": "^10.1.14",
+        "@polkadot/util-crypto": "^10.1.14",
+        "@polkadot/x-fetch": "^10.1.14",
+        "@polkadot/x-global": "^10.1.14",
+        "@polkadot/x-ws": "^10.1.14",
+        "@substrate/connect": "0.7.17",
         "eventemitter3": "^4.0.7",
         "mock-socket": "^9.1.5",
-        "nock": "^13.2.8"
+        "nock": "^13.2.9"
       }
     },
     "@polkadot/types": {
-      "version": "8.12.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/types/-/types-8.12.2.tgz",
-      "integrity": "sha512-hOqLunz4YH51B6AvuemX1cXKf+O8pehEoP3lH+FRKfJ7wyVhqa3WA+aUXhoTQBIuSiOjjC/FEJrRO5AoNO2iCg==",
+      "version": "9.9.4",
+      "resolved": "https://registry.npmjs.org/@polkadot/types/-/types-9.9.4.tgz",
+      "integrity": "sha512-/LJ029S0AtKzvV9JoQtIIeHRP/Xoq8MZmDfdHUEgThRd+uvtQzFyGmcupe4EzX0p5VAx93DUFQKm8vUdHE39Tw==",
       "requires": {
-        "@babel/runtime": "^7.18.6",
-        "@polkadot/keyring": "^10.0.2",
-        "@polkadot/types-augment": "8.12.2",
-        "@polkadot/types-codec": "8.12.2",
-        "@polkadot/types-create": "8.12.2",
-        "@polkadot/util": "^10.0.2",
-        "@polkadot/util-crypto": "^10.0.2",
-        "rxjs": "^7.5.5"
+        "@babel/runtime": "^7.20.1",
+        "@polkadot/keyring": "^10.1.14",
+        "@polkadot/types-augment": "9.9.4",
+        "@polkadot/types-codec": "9.9.4",
+        "@polkadot/types-create": "9.9.4",
+        "@polkadot/util": "^10.1.14",
+        "@polkadot/util-crypto": "^10.1.14",
+        "rxjs": "^7.5.7"
       }
     },
     "@polkadot/types-augment": {
-      "version": "8.12.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/types-augment/-/types-augment-8.12.2.tgz",
-      "integrity": "sha512-47+T12u7HV+g22KryirG7fik5lU1tHgu39wLv8YZ/6jD1hVvgE632fvaCp4qje1F3M82aXobfekO+WOPLCZVsg==",
+      "version": "9.9.4",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-augment/-/types-augment-9.9.4.tgz",
+      "integrity": "sha512-mQNc0kxt3zM6SC+5hJbsg03fxEFpn5nakki+loE2mNsWr1g+rR7LECagAZ4wT2gvdbzWuY/LlRYyDQxe0PwdZg==",
       "requires": {
-        "@babel/runtime": "^7.18.6",
-        "@polkadot/types": "8.12.2",
-        "@polkadot/types-codec": "8.12.2",
-        "@polkadot/util": "^10.0.2"
+        "@babel/runtime": "^7.20.1",
+        "@polkadot/types": "9.9.4",
+        "@polkadot/types-codec": "9.9.4",
+        "@polkadot/util": "^10.1.14"
       }
     },
     "@polkadot/types-codec": {
-      "version": "8.12.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/types-codec/-/types-codec-8.12.2.tgz",
-      "integrity": "sha512-NDa2ZJpJMWC9Un3PtvkyJF86M80gLqSmPyjIR8xxp0DzcD5EsCL8EV79xcOWUGm2lws1C66a4t4He/8ZwPNUqg==",
+      "version": "9.9.4",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-codec/-/types-codec-9.9.4.tgz",
+      "integrity": "sha512-uSHoQQcj4813c9zNkDDH897K6JB0OznTrH5WeZ1wxpjML7lkuTJ2t/GQE9e4q5Ycl7YePZsvEp2qlc3GwrVm/w==",
       "requires": {
-        "@babel/runtime": "^7.18.6",
-        "@polkadot/util": "^10.0.2",
-        "@polkadot/x-bigint": "^10.0.2"
+        "@babel/runtime": "^7.20.1",
+        "@polkadot/util": "^10.1.14",
+        "@polkadot/x-bigint": "^10.1.14"
       }
     },
     "@polkadot/types-create": {
-      "version": "8.12.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/types-create/-/types-create-8.12.2.tgz",
-      "integrity": "sha512-D+Sfj+TwvipO+wl4XbsVkw5AgFdpy5O2JY88CV6L26EGU2OqCcTuenwSGdrsiLWW65m97q9lP7SUphUh39vBhA==",
+      "version": "9.9.4",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-create/-/types-create-9.9.4.tgz",
+      "integrity": "sha512-EOxLryRQ4JVRSRnIMXk3Tjry1tyegNuWK8OUj51A1wHrX76DF9chME27bXUP4d7el1pjqPuQ9/l+/928GG386g==",
       "requires": {
-        "@babel/runtime": "^7.18.6",
-        "@polkadot/types-codec": "8.12.2",
-        "@polkadot/util": "^10.0.2"
+        "@babel/runtime": "^7.20.1",
+        "@polkadot/types-codec": "9.9.4",
+        "@polkadot/util": "^10.1.14"
       }
     },
     "@polkadot/types-known": {
-      "version": "8.12.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/types-known/-/types-known-8.12.2.tgz",
-      "integrity": "sha512-8HCZ3AkczBrCl+TUZD0+2ubLr0BQx+0f/Nnl9yuz1pWygmSEpHrYspmFtDdpMJnNTGZo8vHNOa7smdlijJqlhw==",
+      "version": "9.9.4",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-known/-/types-known-9.9.4.tgz",
+      "integrity": "sha512-BaKXkg3yZLDv31g0CZPJsZDXX01VTjkQ0tmW9U6fmccEq3zHlxbUiXf3aKlwKRJyDWiEOxr4cQ4GT8jj6uEIuA==",
       "requires": {
-        "@babel/runtime": "^7.18.6",
-        "@polkadot/networks": "^10.0.2",
-        "@polkadot/types": "8.12.2",
-        "@polkadot/types-codec": "8.12.2",
-        "@polkadot/types-create": "8.12.2",
-        "@polkadot/util": "^10.0.2"
+        "@babel/runtime": "^7.20.1",
+        "@polkadot/networks": "^10.1.14",
+        "@polkadot/types": "9.9.4",
+        "@polkadot/types-codec": "9.9.4",
+        "@polkadot/types-create": "9.9.4",
+        "@polkadot/util": "^10.1.14"
       }
     },
     "@polkadot/types-support": {
-      "version": "8.12.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/types-support/-/types-support-8.12.2.tgz",
-      "integrity": "sha512-tTksJ4COcVonu/beWQKkF/6fKaArmTwM6iCuxn2PuJziS2Cm1+7D8Rh3ODwwZOseFvHPEco6jnb4DWNclXbZiA==",
+      "version": "9.9.4",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-support/-/types-support-9.9.4.tgz",
+      "integrity": "sha512-vjhdD7B5kdTLhm2iO0QAb7fM4D2ojNUVVocOJotC9NULYtoC+PkPvkvFbw7VQ1H3u7yxyZfWloMtBnCsIp5EAA==",
       "requires": {
-        "@babel/runtime": "^7.18.6",
-        "@polkadot/util": "^10.0.2"
+        "@babel/runtime": "^7.20.1",
+        "@polkadot/util": "^10.1.14"
       }
     },
     "@polkadot/util": {
-      "version": "10.0.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-10.0.2.tgz",
-      "integrity": "sha512-jE1b6Zzltsb/GJV5sFmTSQOlYLd3fipY+DeLS9J+BbsWZW6uUc5x+FNm4pLrYxF1IqiZxwBv1Vi89L14uWZ1rw==",
+      "version": "10.1.14",
+      "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-10.1.14.tgz",
+      "integrity": "sha512-DX8IUd3j+S4HJBs73gz5d7Z592aW5vn/aD7hzFUlBduQIYBy+L1KIoGchpD6hSSOs5HSy7owePmBlp1lPjUZBg==",
       "requires": {
-        "@babel/runtime": "^7.18.6",
-        "@polkadot/x-bigint": "10.0.2",
-        "@polkadot/x-global": "10.0.2",
-        "@polkadot/x-textdecoder": "10.0.2",
-        "@polkadot/x-textencoder": "10.0.2",
-        "@types/bn.js": "^5.1.0",
+        "@babel/runtime": "^7.20.1",
+        "@polkadot/x-bigint": "10.1.14",
+        "@polkadot/x-global": "10.1.14",
+        "@polkadot/x-textdecoder": "10.1.14",
+        "@polkadot/x-textencoder": "10.1.14",
+        "@types/bn.js": "^5.1.1",
         "bn.js": "^5.2.1"
       }
     },
     "@polkadot/util-crypto": {
-      "version": "10.0.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/util-crypto/-/util-crypto-10.0.2.tgz",
-      "integrity": "sha512-0uJFvu5cpRBep0/AcpA8vnXH3gnoe+ADiMKD93AekjxrOVqlrjVHKIf+FbiGv1paRKISxoO5Q2j7nCvDsi1q5w==",
+      "version": "10.1.14",
+      "resolved": "https://registry.npmjs.org/@polkadot/util-crypto/-/util-crypto-10.1.14.tgz",
+      "integrity": "sha512-Iq9C0Snv+pScZ9QgJoH7l++x9wdp9vhS3NMLm8ZqlDCNXUUl/3ViafZCfHRILQD9AsLcykE99mNzFDl3u8jZQA==",
       "requires": {
-        "@babel/runtime": "^7.18.6",
-        "@noble/hashes": "1.1.2",
-        "@noble/secp256k1": "1.6.0",
-        "@polkadot/networks": "10.0.2",
-        "@polkadot/util": "10.0.2",
-        "@polkadot/wasm-crypto": "^6.2.3",
-        "@polkadot/x-bigint": "10.0.2",
-        "@polkadot/x-randomvalues": "10.0.2",
+        "@babel/runtime": "^7.20.1",
+        "@noble/hashes": "1.1.3",
+        "@noble/secp256k1": "1.7.0",
+        "@polkadot/networks": "10.1.14",
+        "@polkadot/util": "10.1.14",
+        "@polkadot/wasm-crypto": "^6.3.1",
+        "@polkadot/x-bigint": "10.1.14",
+        "@polkadot/x-randomvalues": "10.1.14",
         "@scure/base": "1.1.1",
         "ed2curve": "^0.3.0",
         "tweetnacl": "^1.0.3"
       }
     },
     "@polkadot/wasm-bridge": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/wasm-bridge/-/wasm-bridge-6.2.3.tgz",
-      "integrity": "sha512-kDPcUF5uCZJeJUlWtjk6u4KRy+RTObZbIMgZKiuCcQn9n3EYWadONvStfIyKaiFCc3VFVivzH1cUwTFxxTNHHQ==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/wasm-bridge/-/wasm-bridge-6.3.1.tgz",
+      "integrity": "sha512-1TYkHsb9AEFhU9uZj3biEnN2yKQNzdrwSjiTvfCYnt97pnEkKsZI6cku+YPZQv5w/x9CQa5Yua9e2DVVZSivGA==",
       "requires": {
-        "@babel/runtime": "^7.18.6"
+        "@babel/runtime": "^7.18.9"
       }
     },
     "@polkadot/wasm-crypto": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto/-/wasm-crypto-6.2.3.tgz",
-      "integrity": "sha512-Jq08uX16YYySanwN/37n/ZzOFv8T2H4NzLaQNjSGNbFdmKzkrlpw369XRNIVhrKGtK4v09O5ZaF5P9qc0EHgsg==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto/-/wasm-crypto-6.3.1.tgz",
+      "integrity": "sha512-OO8h0qeVkqp4xYZaRVl4iuWOEtq282pNBHDKb6SOJuI2g59eWGcKh4EQU9Me2VP6qzojIqptrkrVt7KQXC68gA==",
       "requires": {
-        "@babel/runtime": "^7.18.6",
-        "@polkadot/wasm-bridge": "6.2.3",
-        "@polkadot/wasm-crypto-asmjs": "6.2.3",
-        "@polkadot/wasm-crypto-init": "6.2.3",
-        "@polkadot/wasm-crypto-wasm": "6.2.3",
-        "@polkadot/wasm-util": "6.2.3"
+        "@babel/runtime": "^7.18.9",
+        "@polkadot/wasm-bridge": "6.3.1",
+        "@polkadot/wasm-crypto-asmjs": "6.3.1",
+        "@polkadot/wasm-crypto-init": "6.3.1",
+        "@polkadot/wasm-crypto-wasm": "6.3.1",
+        "@polkadot/wasm-util": "6.3.1"
       }
     },
     "@polkadot/wasm-crypto-asmjs": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto-asmjs/-/wasm-crypto-asmjs-6.2.3.tgz",
-      "integrity": "sha512-d/eH02d/XB/vIGIQwyoFB4zNRb3h5PlWoXolGeVSuoa8476ouEdaWhy64mFwXBmjfluaeCOFXRs+QbxetwrDZg==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto-asmjs/-/wasm-crypto-asmjs-6.3.1.tgz",
+      "integrity": "sha512-zbombRfA5v/mUWQQhgg2YwaxhRmxRIrvskw65x+lruax3b6xPBFDs7yplopiJU3r8h2pTgQvX/DUksvqz2TCRQ==",
       "requires": {
-        "@babel/runtime": "^7.18.6"
+        "@babel/runtime": "^7.18.9"
       }
     },
     "@polkadot/wasm-crypto-init": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto-init/-/wasm-crypto-init-6.2.3.tgz",
-      "integrity": "sha512-jDFD4ITWbvFgsGiRI61lrzI/eobG8VrI9nVCiDBqQZK7mNnGkyIdnFD1prW36uiv6/tkqSiGGvdb7dEKtmsB+Q==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto-init/-/wasm-crypto-init-6.3.1.tgz",
+      "integrity": "sha512-9yaUBcu+snwjJLmPPGl3cyGRQ1afyFGm16qzTM0sgG/ZCfUlK4uk8KWZe+sBUKgoxb2oXY7Y4WklKgQI1YBdfw==",
       "requires": {
-        "@babel/runtime": "^7.18.6",
-        "@polkadot/wasm-bridge": "6.2.3",
-        "@polkadot/wasm-crypto-asmjs": "6.2.3",
-        "@polkadot/wasm-crypto-wasm": "6.2.3"
+        "@babel/runtime": "^7.18.9",
+        "@polkadot/wasm-bridge": "6.3.1",
+        "@polkadot/wasm-crypto-asmjs": "6.3.1",
+        "@polkadot/wasm-crypto-wasm": "6.3.1"
       }
     },
     "@polkadot/wasm-crypto-wasm": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto-wasm/-/wasm-crypto-wasm-6.2.3.tgz",
-      "integrity": "sha512-bYRhYPcR4MBLAZz8liozr8E11r7j6RLkNHu80z65lZ5AWgjDu2MgYfKxZFWZxg8rB6+V1uYFmb7czUiSWOn4Rg==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto-wasm/-/wasm-crypto-wasm-6.3.1.tgz",
+      "integrity": "sha512-idSlzKGVzCfeCMRHsacRvqwojSaTadFxL/Dbls4z1thvfa3U9Ku0d2qVtlwg7Hj+tYWDiuP8Kygs+6bQwfs0XA==",
       "requires": {
-        "@babel/runtime": "^7.18.6",
-        "@polkadot/wasm-util": "6.2.3"
+        "@babel/runtime": "^7.18.9",
+        "@polkadot/wasm-util": "6.3.1"
       }
     },
     "@polkadot/wasm-util": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/wasm-util/-/wasm-util-6.2.3.tgz",
-      "integrity": "sha512-8BQ9gVSrjdc0MPWN9qtNWlMiK+J8dICu1gZJ+cy/hqKjer2MzwX4SeW2wyL5MkYYHjih3ajMRSoSA+/eY2iEwg==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/wasm-util/-/wasm-util-6.3.1.tgz",
+      "integrity": "sha512-12oAv5J7Yoc9m6jixrSaQCxpOkWOyzHx3DMC8qmLjRiwdBWxqLmImOVRVnFsbaxqSbhBIHRuJphVxWE+GZETDg==",
       "requires": {
-        "@babel/runtime": "^7.18.6"
+        "@babel/runtime": "^7.18.9"
       }
     },
     "@polkadot/x-bigint": {
-      "version": "10.0.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-bigint/-/x-bigint-10.0.2.tgz",
-      "integrity": "sha512-LtfPi+AyZDNe8jQGVmyDfxGyQDdM6ISZEwJD1ieGd4eUbOkfPmn+1t+0rjtxjISZcyP40fSFcLxtL191jDV8Bw==",
+      "version": "10.1.14",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-bigint/-/x-bigint-10.1.14.tgz",
+      "integrity": "sha512-HgrofhI+WM699ozJ9zFZcPUApB2jqwCEOMUgM1jv2WNxF0ILKNDpH08dB8OBy2SKfnKoSgmXwWtxWl1u+mq10A==",
       "requires": {
-        "@babel/runtime": "^7.18.6",
-        "@polkadot/x-global": "10.0.2"
+        "@babel/runtime": "^7.20.1",
+        "@polkadot/x-global": "10.1.14"
       }
     },
     "@polkadot/x-fetch": {
-      "version": "10.0.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-fetch/-/x-fetch-10.0.2.tgz",
-      "integrity": "sha512-vsizrcBNeRWWJhE4ZoCUJ0c68wvy3PiR9jH//B1PTV6OaqpdalpwXG6Xtpli8yc0hOOUH/87u8b/x2f/2vhZcQ==",
+      "version": "10.1.14",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-fetch/-/x-fetch-10.1.14.tgz",
+      "integrity": "sha512-07H9unwv0tT5RQRkj1WE67ug6x6RlUfGN/mJWSKqf0JjsfQlPMKDC9yZW1oUSsasBUyIf0qbspuVSyhZu+0cpg==",
       "requires": {
-        "@babel/runtime": "^7.18.6",
-        "@polkadot/x-global": "10.0.2",
+        "@babel/runtime": "^7.20.1",
+        "@polkadot/x-global": "10.1.14",
         "@types/node-fetch": "^2.6.2",
-        "node-fetch": "^3.2.6"
+        "node-fetch": "^3.3.0"
       }
     },
     "@polkadot/x-global": {
-      "version": "10.0.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-10.0.2.tgz",
-      "integrity": "sha512-IlxSH36RjcQTImufaJCtvommMmkNWbwOy+/Z7FEOKUOcoiPaUhHU3CzWser+EtClckx7qPLY5lZ59Pxf7HWupQ==",
+      "version": "10.1.14",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-10.1.14.tgz",
+      "integrity": "sha512-ye3Yx2bfIoHf5t78rbDad587J16JanrcfpGSWoknWOZ7wmatj/CJKWhJ/VKMPfJGEJm2LidH1B0W8QDfrMEmTA==",
       "requires": {
-        "@babel/runtime": "^7.18.6"
+        "@babel/runtime": "^7.20.1"
       }
     },
     "@polkadot/x-randomvalues": {
-      "version": "10.0.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-randomvalues/-/x-randomvalues-10.0.2.tgz",
-      "integrity": "sha512-kYbNeeOaDEnNqVhIgh8ds9YC79Tji5/HDqQymx7Xb3YmTagdOAe2klrTRJzVfsUKljzhlVOuF3Zcf/PRNbt/2w==",
+      "version": "10.1.14",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-randomvalues/-/x-randomvalues-10.1.14.tgz",
+      "integrity": "sha512-mrZho4qogLZmox7wuP1XF03HTZ4CwAjzV7RvKmwH8ToNCR6E4NRo2btgG67Z0K+bUOQRbXWL2hQazusa2p2N6w==",
       "requires": {
-        "@babel/runtime": "^7.18.6",
-        "@polkadot/x-global": "10.0.2"
+        "@babel/runtime": "^7.20.1",
+        "@polkadot/x-global": "10.1.14"
       }
     },
     "@polkadot/x-textdecoder": {
-      "version": "10.0.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-10.0.2.tgz",
-      "integrity": "sha512-EI1+Osrfadtm4XFfdcjYgV/1yYoPoFaIJfZiPphPSy/4Ceeblmz9T2hWPdJ3uWtPpk6FkhxudB44Y1JuCwXBjg==",
+      "version": "10.1.14",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-10.1.14.tgz",
+      "integrity": "sha512-qwbeR8v6a5Z9MdbjzcY5gFiRWbp8bBVoDEf1Dd+yH9/UAyFXodlMKs3irDdVhGVPCbZWQTVDEZRUgEqRxwKC7w==",
       "requires": {
-        "@babel/runtime": "^7.18.6",
-        "@polkadot/x-global": "10.0.2"
+        "@babel/runtime": "^7.20.1",
+        "@polkadot/x-global": "10.1.14"
       }
     },
     "@polkadot/x-textencoder": {
-      "version": "10.0.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-10.0.2.tgz",
-      "integrity": "sha512-iTLC700ExtRFsP+fE+dA5CO0xjQ46XeQqbJxa7wJK3aKrzpogyTLZXc0O5ISE1xltOmsQSA9QOELMP113kZkvA==",
+      "version": "10.1.14",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-10.1.14.tgz",
+      "integrity": "sha512-MC30rtQiFVgQDSP8wO5wa1so5tW3T7qs/DCT018A4zgjiK+uFdIGOerAgoxcNw3yC6IGnPIL5lsRO/1C9N60zA==",
       "requires": {
-        "@babel/runtime": "^7.18.6",
-        "@polkadot/x-global": "10.0.2"
+        "@babel/runtime": "^7.20.1",
+        "@polkadot/x-global": "10.1.14"
       }
     },
     "@polkadot/x-ws": {
-      "version": "10.0.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-ws/-/x-ws-10.0.2.tgz",
-      "integrity": "sha512-eH8WJ6jKobfUGLRAGj65wKUB2pwbT7RflebQbbcG8Khx9INRjuwLGc+jAiuf0StOZiqVVJsMUayVgsddO8hIvQ==",
+      "version": "10.1.14",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-ws/-/x-ws-10.1.14.tgz",
+      "integrity": "sha512-xgyMYR34sHxKCtQUJ2btFAyN3fK1OqCqvAyRYmU52801aguLstRhVPAZxXJp3Dahs91FX/h/ZZzmwXD01tJtyA==",
       "requires": {
-        "@babel/runtime": "^7.18.6",
-        "@polkadot/x-global": "10.0.2",
+        "@babel/runtime": "^7.20.1",
+        "@polkadot/x-global": "10.1.14",
         "@types/websocket": "^1.0.5",
         "websocket": "^1.0.34"
       }
@@ -8581,39 +8580,38 @@
       "integrity": "sha512-ZxOhsSyxYwLJj3pLZCefNitxsj093tb2vq90mp2txoYeBqbcjDjqFhyM8eUjq/uFm6zJ+mUuqxlS2FkuSY1MTA=="
     },
     "@substrate/connect": {
-      "version": "0.7.7",
-      "resolved": "https://registry.npmjs.org/@substrate/connect/-/connect-0.7.7.tgz",
-      "integrity": "sha512-uFRF06lC42ZZixxwkzRB61K1uYvR1cTZ7rI98RW7T+eWbCFrafyVk0pk6J+4oN05gZkhou+VK3hrRCU6Doy2xQ==",
+      "version": "0.7.17",
+      "resolved": "https://registry.npmjs.org/@substrate/connect/-/connect-0.7.17.tgz",
+      "integrity": "sha512-s0XBmGpUCFWZFa+TS0TEvOKtWjJP2uT4xKmvzApH8INB5xbz79wqWFX6WWh3AlK/X1P0Smt+RVEH7HQiLJAYAw==",
       "requires": {
-        "@substrate/connect-extension-protocol": "^1.0.0",
-        "@substrate/smoldot-light": "0.6.19",
+        "@substrate/connect-extension-protocol": "^1.0.1",
+        "@substrate/smoldot-light": "0.7.7",
         "eventemitter3": "^4.0.7"
       }
     },
     "@substrate/connect-extension-protocol": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@substrate/connect-extension-protocol/-/connect-extension-protocol-1.0.0.tgz",
-      "integrity": "sha512-nFVuKdp71hMd/MGlllAOh+a2hAqt8m6J2G0aSsS/RcALZexxF9jodbFc62ni8RDtJboeOfXAHhenYOANvJKPIg=="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@substrate/connect-extension-protocol/-/connect-extension-protocol-1.0.1.tgz",
+      "integrity": "sha512-161JhCC1csjH3GE5mPLEd7HbWtwNSPJBg3p1Ksz9SFlTzj/bgEwudiRN2y5i0MoLGCIJRYKyKGMxVnd29PzNjg=="
     },
     "@substrate/smoldot-light": {
-      "version": "0.6.19",
-      "resolved": "https://registry.npmjs.org/@substrate/smoldot-light/-/smoldot-light-0.6.19.tgz",
-      "integrity": "sha512-Xi+v1cdURhTwx7NH+9fa1U9m7VGP61GvB6qwev9HrZXlGbQiUIvySxPlH/LMsq3mwgiRYkokPhcaZEHufY7Urg==",
+      "version": "0.7.7",
+      "resolved": "https://registry.npmjs.org/@substrate/smoldot-light/-/smoldot-light-0.7.7.tgz",
+      "integrity": "sha512-ksxeAed6dIUtYSl0f8ehgWQjwXnpDGTIJt+WVRIGt3OObZkA96ZdBWx0xP7GrXZtj37u4n/Y1z7TyTm4bwQvrw==",
       "requires": {
-        "buffer": "^6.0.1",
         "pako": "^2.0.4",
-        "websocket": "^1.0.32"
+        "ws": "^8.8.1"
       }
     },
     "@substrate/ss58-registry": {
-      "version": "1.23.0",
-      "resolved": "https://registry.npmjs.org/@substrate/ss58-registry/-/ss58-registry-1.23.0.tgz",
-      "integrity": "sha512-LuQje7n48GXSsp1aGI6UEmNVtlh7OzQ6CN1Hd9VGUrshADwMB0lRZ5bxnffmqDR4vVugI7h0NN0AONhIW1eHGg=="
+      "version": "1.35.0",
+      "resolved": "https://registry.npmjs.org/@substrate/ss58-registry/-/ss58-registry-1.35.0.tgz",
+      "integrity": "sha512-cIY3J7RlT4mfPNFwd2mv1q9vTp/shImw2gN2y2outMhOcagH/HG+W8/JohpifjxPC/1pbQ0Z8nxfL5Td3EchcA=="
     },
     "@types/bn.js": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-5.1.0.tgz",
-      "integrity": "sha512-QSSVYj7pYFN49kW77o2s9xTCwZ8F2xLbjLLSEVh8D2F4JUhZtPAGOFLTD+ffqksBx/u4cE/KImFjyhqCjn/LIA==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-5.1.1.tgz",
+      "integrity": "sha512-qNrYbZqMx0uJAfKnKclPh+dTwK33KfLHYqtyODwd5HnXOjnkhc4qgn3BrK6RWyGZm5+sIFE7Q7Vz6QQtJB7w7g==",
       "requires": {
         "@types/node": "*"
       }
@@ -9119,9 +9117,9 @@
       "integrity": "sha512-a7ZpuTZU1TRtnwyCNW3I5dc0wWNC3VR9S++Ewyk2HHZdrO3CQJqSpd+95Us590V6AL7JqUAH2IwZ/398PmNFgw=="
     },
     "bufferutil": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.0.6.tgz",
-      "integrity": "sha512-jduaYOYtnio4aIAyc6UbvPCVcgq7nYpVnucyxr6eCYg/Woad9Hf/oxxBRDnGGjPfjUm6j5O/uBWhIu4iLebFaw==",
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.0.7.tgz",
+      "integrity": "sha512-kukuqc39WOHtdxtw4UScxF/WVnMFVSQVKhtx3AjZJzhd0RGZZldcrfSEbVsWWe6KNH253574cq5F+wpv0G9pJw==",
       "requires": {
         "node-gyp-build": "^4.3.0"
       }
@@ -9663,9 +9661,9 @@
       }
     },
     "es5-ext": {
-      "version": "0.10.61",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.61.tgz",
-      "integrity": "sha512-yFhIqQAzu2Ca2I4SE2Au3rxVfmohU9Y7wqGR+s7+H7krk26NXhIRAZDgqd6xqjCEFUomDEA3/Bo/7fKmIkW1kA==",
+      "version": "0.10.62",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.62.tgz",
+      "integrity": "sha512-BHLqn0klhEpnOKSrzn/Xsz2UIW8j+cGmo9JLzr8BiUapV8hPL9+FliFqjwr9ngW7jWdnxv6eO+/LqyhJVqgrjA==",
       "requires": {
         "es6-iterator": "^2.0.3",
         "es6-symbol": "^3.1.3",
@@ -10066,17 +10064,17 @@
       }
     },
     "ext": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/ext/-/ext-1.6.0.tgz",
-      "integrity": "sha512-sdBImtzkq2HpkdRLtlLWDa6w4DX22ijZLKx8BMPUuKe1c5lbN6xwQDQCxSfxBQnHZ13ls/FH0MQZx/q/gr6FQg==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/ext/-/ext-1.7.0.tgz",
+      "integrity": "sha512-6hxeJYaL110a9b5TEJSj0gojyHQAmA2ch5Os+ySCiA1QGdS697XWY1pzsrSjqA9LDEEgdB/KypIlR59RcLuHYw==",
       "requires": {
-        "type": "^2.5.0"
+        "type": "^2.7.2"
       },
       "dependencies": {
         "type": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/type/-/type-2.6.0.tgz",
-          "integrity": "sha512-eiDBDOmkih5pMbo9OqsqPRGMljLodLcwd5XD5JbtNB0o89xZAwynY9EdCDsJU7LtcVCClu9DvM7/0Ep1hYX3EQ=="
+          "version": "2.7.2",
+          "resolved": "https://registry.npmjs.org/type/-/type-2.7.2.tgz",
+          "integrity": "sha512-dzlvlNlt6AXU7EBSfpAscydQ7gXB+pPGsPnfJnZpiNJBDj7IaJzQlBZYGdEi4R9HmPdBv2XmWJ6YUtoTa7lmCw=="
         }
       }
     },
@@ -11423,9 +11421,9 @@
       "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ=="
     },
     "node-fetch": {
-      "version": "3.2.10",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.2.10.tgz",
-      "integrity": "sha512-MhuzNwdURnZ1Cp4XTazr69K0BTizsBroX7Zx3UgDSVcZYKF/6p0CBe4EUb/hLqmzVhl0UpYfgRljQ4yxE+iCxA==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.0.tgz",
+      "integrity": "sha512-BKwRP/O0UvoMKp7GNdwPlObhYGB5DQqwhEDQlNKuoqwVYSxkSZCSbHjnFFmUEtwSKRPU4kNK8PbDYYitwaE3QA==",
       "requires": {
         "data-uri-to-buffer": "^4.0.0",
         "fetch-blob": "^3.1.4",
@@ -11936,9 +11934,9 @@
       "integrity": "sha512-HAKu/fG3HpHFO0AA8WE8q2g+gBJaZ9MG7fcKk+IJPLTGAD6Psw4443l+9DGRbOIh3/aXr7Phy0TjilYivJo5XQ=="
     },
     "pako": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/pako/-/pako-2.0.4.tgz",
-      "integrity": "sha512-v8tweI900AUkZN6heMU/4Uy4cXRc2AYNRggVmTR+dEncawDJgCdLMximOVA2p4qO57WMynangsfGRb5WD6L1Bg=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
+      "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug=="
     },
     "parent-module": {
       "version": "1.0.1",
@@ -12479,9 +12477,9 @@
       }
     },
     "regenerator-runtime": {
-      "version": "0.13.9",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
-      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA=="
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
     },
     "regexpp": {
       "version": "3.2.0",
@@ -12562,9 +12560,9 @@
       }
     },
     "rxjs": {
-      "version": "7.5.6",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.6.tgz",
-      "integrity": "sha512-dnyv2/YsXhnm461G+R/Pe5bWP41Nm6LBXEYWI6eiFP4fiwx6WRI/CD0zbdVAudd9xwLEF2IDcKXLHit0FYjUzw==",
+      "version": "7.5.7",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.7.tgz",
+      "integrity": "sha512-z9MzKh/UcOqB3i20H6rtrlaE/CgjLOvheWK/9ILrbhROGTweAi1BaFsTT9FbwZi5Trr1qNRs+MXkhmR06awzQA==",
       "requires": {
         "tslib": "^2.1.0"
       }
@@ -13098,9 +13096,9 @@
       "integrity": "sha512-yIQdxJpgkPamPPAPuGdS7Q548rLhny42tg8d4vyTNzFqvOnwqrgHXvgehT09U7fwrzxi3RxCiXjoNUNnNOlQ8A=="
     },
     "utf-8-validate": {
-      "version": "5.0.9",
-      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.9.tgz",
-      "integrity": "sha512-Yek7dAy0v3Kl0orwMlvi7TPtiCNrdfHNd7Gcc/pLq4BLXqfAmd0J7OWMizUQnTTJsyjKn02mU7anqwfmUP4J8Q==",
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
+      "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
       "requires": {
         "node-gyp-build": "^4.3.0"
       }
@@ -13225,6 +13223,12 @@
         "signal-exit": "^3.0.2",
         "typedarray-to-buffer": "^3.1.5"
       }
+    },
+    "ws": {
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
+      "integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
+      "requires": {}
     },
     "xtend": {
       "version": "4.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/dscp-identity-service",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/dscp-identity-service",
-      "version": "1.8.0",
+      "version": "1.8.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@polkadot/api": "^9.9.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/dscp-identity-service",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "description": "Identity Service for DSCP",
   "type": "module",
   "main": "app/index.js",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "homepage": "https://github.com/digicatapult/dscp-identity-service#readme",
   "dependencies": {
-    "@digicatapult/dscp-node": "^4.3.1",
+    "@polkadot/api": "^9.9.4",
     "body-parser": "^1.20.1",
     "compression": "^1.7.4",
     "cors": "^2.8.5",


### PR DESCRIPTION
Since `dscp-node` was updated to use a more recent tag of Substrate, we no longer need the `dscp-node` extended types config when connecting to the node via polkadot.js  

This means we can remove usage of `@digicatapult/dscp-node` package and replace with direct use of `@polkadot/api`