### PR TITLE
Add external AUTH_TYPE

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ npx knex migrate:latest --env test
 | DB_USERNAME          |    Y     |    -    | Username to connect to the database with                                                                                      |
 | DB_PASSWORD          |    Y     |    -    | Password to connect to the database with                                                                                      |
 | SELF_ADDRESS         |    N     |    -    | Instance wallet address that is returned by `/self` endpoint                                                                  |
-| AUTH_TYPE            |    N     | `NONE`  | Authentication type for routes on the service. Valid values: [`NONE`, `JWT`]                                                  |
+| AUTH_TYPE            |    N     | `NONE`  | Authentication type for routes on the service. Valid values: [`NONE`, `JWT`, `EXTERNAL`]                                      |
 
 The following environment variables are additionally used when `AUTH_TYPE : 'JWT'`
 

--- a/app/env.js
+++ b/app/env.js
@@ -19,7 +19,7 @@ const AUTH_ENVS = {
 }
 
 const { AUTH_TYPE } = envalid.cleanEnv(process.env, {
-  AUTH_TYPE: envalid.str({ default: 'NONE', choices: ['NONE', 'JWT'] }),
+  AUTH_TYPE: envalid.str({ default: 'NONE', choices: ['NONE', 'JWT', 'EXTERNAL'] }),
 })
 
 const vars = envalid.cleanEnv(

--- a/app/util/authUtil.js
+++ b/app/util/authUtil.js
@@ -54,6 +54,7 @@ export const getDefaultSecurity = () => {
     case 'NONE':
       return []
     case 'JWT':
+    case 'EXTERNAL':
       return [{ bearerAuth: [] }]
     default:
       return []

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/dscp-identity-service",
-  "version": "1.8.4",
+  "version": "1.8.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/dscp-identity-service",
-      "version": "1.8.4",
+      "version": "1.8.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@polkadot/api": "^10.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/dscp-identity-service",
-  "version": "1.8.4",
+  "version": "1.8.5",
   "description": "Identity Service for DSCP",
   "type": "module",
   "main": "app/index.js",


### PR DESCRIPTION
Add an `AUTH_TYPE: EXTERNAL` that keeps no auth at the service level (default behaviour) but displays swagger authentication options so a `Authorization` header can be added easily. Used when `dscp-identity-service` is deployed to authorise at ingress level rather than service level. 

`AUTH_TYPE=EXTERNAL npm run dev`
![image](https://user-images.githubusercontent.com/40722025/224712575-e368fa46-ab87-477e-ae1e-8ab1c932d24c.png)
