### PR TITLE
Fixing BearerAuth casing everywhere

### DIFF
--- a/app/api-v1/api-doc.js
+++ b/app/api-v1/api-doc.js
@@ -66,7 +66,7 @@ const apiDoc = {
       },
     },
     securitySchemes: {
-      bearerAuth: {
+      BearerAuth: {
         type: 'http',
         scheme: 'bearer',
         bearerFormat: 'JWT',

--- a/app/server.js
+++ b/app/server.js
@@ -56,7 +56,7 @@ export async function createHttpServer() {
   const securityHandlers =
     AUTH_TYPE === 'JWT'
       ? {
-          bearerAuth: (req) => {
+          BearerAuth: (req) => {
             return verifyJwks(req.headers['authorization'])
           },
         }

--- a/app/util/authUtil.js
+++ b/app/util/authUtil.js
@@ -55,7 +55,7 @@ export const getDefaultSecurity = () => {
       return []
     case 'JWT':
     case 'EXTERNAL':
-      return [{ bearerAuth: [] }]
+      return [{ BearerAuth: [] }]
     default:
       return []
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/dscp-identity-service",
-  "version": "1.8.28",
+  "version": "1.8.29",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/dscp-identity-service",
-      "version": "1.8.28",
+      "version": "1.8.29",
       "license": "Apache-2.0",
       "dependencies": {
         "@polkadot/api": "^10.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/dscp-identity-service",
-  "version": "1.8.28",
+  "version": "1.8.29",
   "description": "Identity Service for DSCP",
   "type": "module",
   "main": "app/index.js",


### PR DESCRIPTION
This should fix a bug so we consistently use `BearerAuth` everywhere instead of `bearerAuth`