### PR TITLE
Use address if alias is null

### DIFF
--- a/app/api-v1/api-doc.js
+++ b/app/api-v1/api-doc.js
@@ -58,8 +58,8 @@ const apiDoc = {
       Alias: {
         type: 'string',
         minLength: 1,
-        maxLength: 255,
-        pattern: '(?!^[1-9A-HJ-NP-Za-km-z]{48}$)^.{1,255}$',
+        maxLength: 50,
+        pattern: '(?!^[1-9A-HJ-NP-Za-km-z]{48}$)^.{1,50}$',
       },
       AddressOrAlias: {
         oneOf: [{ $ref: '#/components/schemas/Alias' }, { $ref: '#/components/schemas/Address' }],

--- a/app/api-v1/routes/members/{aliasOrAddress}.js
+++ b/app/api-v1/routes/members/{aliasOrAddress}.js
@@ -12,27 +12,27 @@ export default function (apiService) {
   const doc = {
     GET: async function (req, res) {
       const { aliasOrAddress } = req.params
-      let result = {},
+      let member = {},
         validationErrors
 
       if (addrRegex.test(aliasOrAddress)) {
-        result = await apiService.getMembersByAddress(aliasOrAddress)
+        member = await apiService.getMemberByAddress(aliasOrAddress)
       } else if (aliasRegex.test(aliasOrAddress)) {
-        result = await apiService.getMembersByAlias(aliasOrAddress)
+        member = await apiService.getMemberByAlias(aliasOrAddress)
       } else {
         res.status(400).json({ message: 'Invalid member Alias or Address' })
         return
       }
 
-      validationErrors = validateMemberAddressResponse(400, result)
+      validationErrors = validateMemberAddressResponse(400, member)
       if (validationErrors) {
         res.status(400).json(validationErrors)
         return
-      } else if (result.length === 0) {
+      } else if (!member) {
         res.status(404).json({ message: 'Member does not exist' })
         return
       } else {
-        res.status(200).json(result[0])
+        res.status(200).json(member)
         return
       }
     },

--- a/app/api-v1/routes/members/{aliasOrAddress}.js
+++ b/app/api-v1/routes/members/{aliasOrAddress}.js
@@ -2,11 +2,9 @@ import {
   memberAddressResponses,
   validateMemberAddressResponse,
 } from '../../validators/memberAddressResponseValidator.js'
-import apiDoc from '../../api-doc.js'
-import { getDefaultSecurity } from '../../../util/authUtil.js'
 
-const addrRegex = new RegExp(apiDoc.components.schemas.Address.pattern)
-const aliasRegex = new RegExp(apiDoc.components.schemas.Alias.pattern)
+import { getDefaultSecurity } from '../../../util/authUtil.js'
+import { addrRegex, aliasRegex } from '../../services/apiService.js'
 
 export default function (apiService) {
   const doc = {

--- a/app/api-v1/routes/self.js
+++ b/app/api-v1/routes/self.js
@@ -8,7 +8,7 @@ export default function (apiService) {
   const doc = {
     GET: async function (req, res) {
       const [self] = await apiService.getMembersByAddress(SELF_ADDRESS)
-      const response = self || { address: SELF_ADDRESS, alias: null }
+      const response = self || { address: SELF_ADDRESS, alias: SELF_ADDRESS }
       const errors = validateSelfResponse(400, response)
       if (errors) return res.status(400).send(errors)
       res.status(200).json(response)

--- a/app/api-v1/routes/self.js
+++ b/app/api-v1/routes/self.js
@@ -7,11 +7,10 @@ const { SELF_ADDRESS } = env
 export default function (apiService) {
   const doc = {
     GET: async function (req, res) {
-      const [self] = await apiService.getMembersByAddress(SELF_ADDRESS)
-      const response = self || { address: SELF_ADDRESS, alias: SELF_ADDRESS }
-      const errors = validateSelfResponse(400, response)
+      const self = await apiService.getMemberByAddress(SELF_ADDRESS)
+      const errors = validateSelfResponse(400, self)
       if (errors) return res.status(400).send(errors)
-      res.status(200).json(response)
+      res.status(200).json(self)
     },
   }
 

--- a/app/api-v1/services/apiService.js
+++ b/app/api-v1/services/apiService.js
@@ -27,8 +27,8 @@ export async function getMemberByAddress(address) {
 export async function putMemberAlias(address, { alias }) {
   const members = await getMembersByAddressDb({ address })
 
-  if (addrRegex.test(alias)) {
-    return { statusCode: 400, result: { message: 'can not set member alias to be an address' } }
+  if (!aliasRegex.test(alias)) {
+    return { statusCode: 400, result: { message: 'invalid alias' } }
   }
 
   // check members by address for matching address and alias or members by alias

--- a/app/api-v1/services/apiService.js
+++ b/app/api-v1/services/apiService.js
@@ -5,12 +5,19 @@ export async function findMembers() {
   return getMembersUtil()
 }
 
-export async function getMembersByAlias(alias) {
-  return await getMembersByAliasDb({ alias })
+export async function getMemberByAlias(alias) {
+  const [member] = await getMembersByAliasDb({ alias })
+  return member
 }
 
-export async function getMembersByAddress(address) {
-  return await getMembersByAddressDb({ address })
+export async function getMemberByAddress(address) {
+  const [member] = await getMembersByAddressDb({ address })
+  if (member) return member
+
+  // if no alias in db, check if member is on-chain
+  const chainMembers = await getMembersUtil()
+  const validMembers = chainMembers.toJSON()
+  return validMembers.includes(address) ? { address: address, alias: address } : null
 }
 
 export async function putMemberAlias(address, { alias }) {
@@ -40,7 +47,7 @@ export async function putMemberAlias(address, { alias }) {
 
 export default {
   findMembers,
-  getMembersByAlias,
-  getMembersByAddress,
+  getMemberByAlias,
+  getMemberByAddress,
   putMemberAlias,
 }

--- a/app/api-v1/services/apiService.js
+++ b/app/api-v1/services/apiService.js
@@ -1,5 +1,9 @@
 import { getMembers as getMembersUtil } from '../../util/appUtil.js'
 import { getMembersByAddressDb, createMemberAliasDb, updateMemberAliasDb, getMembersByAliasDb } from '../../db.js'
+import apiDoc from '../api-doc.js'
+
+export const addrRegex = new RegExp(apiDoc.components.schemas.Address.pattern)
+export const aliasRegex = new RegExp(apiDoc.components.schemas.Alias.pattern)
 
 export async function findMembers() {
   return getMembersUtil()
@@ -22,6 +26,10 @@ export async function getMemberByAddress(address) {
 
 export async function putMemberAlias(address, { alias }) {
   const members = await getMembersByAddressDb({ address })
+
+  if (addrRegex.test(alias)) {
+    return { statusCode: 400, result: { message: 'can not set member alias to be an address' } }
+  }
 
   // check members by address for matching address and alias or members by alias
   if ((members.length && members[0].alias === alias) || (await getMembersByAliasDb({ alias })).length) {

--- a/app/server.js
+++ b/app/server.js
@@ -56,7 +56,7 @@ export async function createHttpServer() {
   const securityHandlers =
     AUTH_TYPE === 'JWT'
       ? {
-          bearerAuth: (req) => {
+          BearerAuth: (req) => {
             return verifyJwks(req.headers['authorization'])
           },
         }

--- a/app/util/appUtil.js
+++ b/app/util/appUtil.js
@@ -29,9 +29,10 @@ export async function membershipReducer(members) {
   const memberAliases = await getMemberAliasesDb(members)
 
   return members.reduce((acc, item) => {
-    const memberAlias = memberAliases.find(({ address }) => address === item) || null
+    const memberAlias = memberAliases.find(({ address }) => address === item)
 
-    acc.push({ address: item, alias: memberAlias ? memberAlias.alias : memberAlias })
+    // set alias as address if no alias found
+    acc.push({ address: item, alias: memberAlias ? memberAlias.alias : item })
 
     return acc
   }, [])

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/dscp-identity-service",
-  "version": "1.8.27",
+  "version": "1.9.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/dscp-identity-service",
-      "version": "1.8.27",
+      "version": "1.9.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@polkadot/api": "^10.3.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/dscp-identity-service",
-  "version": "1.8.27",
+  "version": "1.9.0",
   "description": "Identity Service for DSCP",
   "type": "module",
   "main": "app/index.js",

--- a/test/integration/routes.test.js
+++ b/test/integration/routes.test.js
@@ -292,5 +292,15 @@ describe('routes', function () {
         alias: 'TEST',
       })
     })
+
+    test('put address as an alias', async function () {
+      const invalidAlias = USER_ALICE_TOKEN
+      const expectedResult = { message: 'can not set member alias to be an address' }
+
+      const res = await putMemberAliasRoute(app, null, USER_CHARLIE_TOKEN, { alias: invalidAlias })
+
+      expect(res.status).to.equal(400)
+      expect(res.body).deep.equal(expectedResult)
+    })
   })
 })

--- a/test/integration/routes.test.js
+++ b/test/integration/routes.test.js
@@ -295,7 +295,7 @@ describe('routes', function () {
 
     test('put address as an alias', async function () {
       const invalidAlias = USER_ALICE_TOKEN
-      const expectedResult = { message: 'can not set member alias to be an address' }
+      const expectedResult = { message: 'invalid alias' }
 
       const res = await putMemberAliasRoute(app, null, USER_CHARLIE_TOKEN, { alias: invalidAlias })
 

--- a/test/integration/routes.test.js
+++ b/test/integration/routes.test.js
@@ -248,6 +248,18 @@ describe('routes', function () {
       expect(res.body).deep.equal(expectedResult)
     })
 
+    test('get member with null alias by address', async function () {
+      const expectedResult = {
+        address: USER_CHARLIE_TOKEN,
+        alias: USER_CHARLIE_TOKEN,
+      }
+
+      const res = await getMemberByAliasOrAddressRoute(app, USER_CHARLIE_TOKEN, null)
+
+      expect(res.status).to.equal(200)
+      expect(res.body).deep.equal(expectedResult)
+    })
+
     test('get member by address', async function () {
       await putMemberAliasRoute(app, null, USER_CHARLIE_TOKEN, { alias: 'CHARLIE' })
 

--- a/test/integration/routes.test.js
+++ b/test/integration/routes.test.js
@@ -62,9 +62,9 @@ describe('routes', function () {
 
     test('return membership members', async function () {
       const expectedResult = [
-        { address: USER_BOB_TOKEN, alias: null },
-        { address: USER_CHARLIE_TOKEN, alias: null },
-        { address: USER_ALICE_TOKEN, alias: null },
+        { address: USER_BOB_TOKEN, alias: USER_BOB_TOKEN },
+        { address: USER_CHARLIE_TOKEN, alias: USER_CHARLIE_TOKEN },
+        { address: USER_ALICE_TOKEN, alias: USER_ALICE_TOKEN },
       ]
 
       const res = await getMembersRoute(app, authToken)
@@ -75,9 +75,9 @@ describe('routes', function () {
 
     test('return membership members with aliases', async function () {
       const expectedResult = [
-        { address: USER_BOB_TOKEN, alias: null },
+        { address: USER_BOB_TOKEN, alias: USER_BOB_TOKEN },
         { address: USER_CHARLIE_TOKEN, alias: 'CHARLIE' },
-        { address: USER_ALICE_TOKEN, alias: null },
+        { address: USER_ALICE_TOKEN, alias: USER_ALICE_TOKEN },
       ]
 
       await putMemberAliasRoute(app, authToken, USER_CHARLIE_TOKEN, { alias: 'CHARLIE' })
@@ -130,7 +130,7 @@ describe('routes', function () {
       await putMemberAliasRoute(app, authToken, USER_CHARLIE_TOKEN, { alias: 'CHARLIE' })
 
       const expectedResult = {
-        address: '5FLSigC9HGRKVhB9FiEo4Y3koPsNmBmLJbpXg2mp1hXcS59Y',
+        address: USER_CHARLIE_TOKEN,
         alias: 'CHARLIE',
       }
 
@@ -164,15 +164,11 @@ describe('routes', function () {
       await putMemberAliasRoute(app, authToken, USER_CHARLIE_TOKEN, { alias: 'CHARLIE' })
 
       const expectedResult = {
-        address: '5FLSigC9HGRKVhB9FiEo4Y3koPsNmBmLJbpXg2mp1hXcS59Y',
+        address: USER_CHARLIE_TOKEN,
         alias: 'CHARLIE',
       }
 
-      const res = await getMemberByAliasOrAddressRoute(
-        app,
-        '5FLSigC9HGRKVhB9FiEo4Y3koPsNmBmLJbpXg2mp1hXcS59Y',
-        authToken
-      )
+      const res = await getMemberByAliasOrAddressRoute(app, USER_CHARLIE_TOKEN, authToken)
 
       expect(res.status).to.equal(200)
       expect(res.body).deep.equal(expectedResult)
@@ -182,17 +178,17 @@ describe('routes', function () {
       const { status, body } = await getSelfAddress(app, authToken)
       expect(status).to.equal(200)
       expect(body).to.deep.equal({
-        address: '5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty',
-        alias: null,
+        address: USER_BOB_TOKEN,
+        alias: USER_BOB_TOKEN,
       })
     })
 
     test('get self address with alias', async function () {
-      await putMemberAliasRoute(app, authToken, '5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty', { alias: 'TEST' })
+      await putMemberAliasRoute(app, authToken, USER_BOB_TOKEN, { alias: 'TEST' })
       const { status, body } = await getSelfAddress(app, authToken)
       expect(status).to.equal(200)
       expect(body).to.deep.equal({
-        address: '5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty',
+        address: USER_BOB_TOKEN,
         alias: 'TEST',
       })
     })
@@ -213,9 +209,9 @@ describe('routes', function () {
 
     test('return membership members', async function () {
       const expectedResult = [
-        { address: USER_BOB_TOKEN, alias: null },
-        { address: USER_CHARLIE_TOKEN, alias: null },
-        { address: USER_ALICE_TOKEN, alias: null },
+        { address: USER_BOB_TOKEN, alias: USER_BOB_TOKEN },
+        { address: USER_CHARLIE_TOKEN, alias: USER_CHARLIE_TOKEN },
+        { address: USER_ALICE_TOKEN, alias: USER_ALICE_TOKEN },
       ]
 
       const res = await getMembersRoute(app, null)
@@ -226,9 +222,9 @@ describe('routes', function () {
 
     test('return membership members with aliases', async function () {
       const expectedResult = [
-        { address: USER_BOB_TOKEN, alias: null },
+        { address: USER_BOB_TOKEN, alias: USER_BOB_TOKEN },
         { address: USER_CHARLIE_TOKEN, alias: 'CHARLIE' },
-        { address: USER_ALICE_TOKEN, alias: null },
+        { address: USER_ALICE_TOKEN, alias: USER_ALICE_TOKEN },
       ]
 
       await putMemberAliasRoute(app, null, USER_CHARLIE_TOKEN, { alias: 'CHARLIE' })
@@ -242,7 +238,7 @@ describe('routes', function () {
       await putMemberAliasRoute(app, null, USER_CHARLIE_TOKEN, { alias: 'CHARLIE' })
 
       const expectedResult = {
-        address: '5FLSigC9HGRKVhB9FiEo4Y3koPsNmBmLJbpXg2mp1hXcS59Y',
+        address: USER_CHARLIE_TOKEN,
         alias: 'CHARLIE',
       }
 
@@ -256,11 +252,11 @@ describe('routes', function () {
       await putMemberAliasRoute(app, null, USER_CHARLIE_TOKEN, { alias: 'CHARLIE' })
 
       const expectedResult = {
-        address: '5FLSigC9HGRKVhB9FiEo4Y3koPsNmBmLJbpXg2mp1hXcS59Y',
+        address: USER_CHARLIE_TOKEN,
         alias: 'CHARLIE',
       }
 
-      const res = await getMemberByAliasOrAddressRoute(app, '5FLSigC9HGRKVhB9FiEo4Y3koPsNmBmLJbpXg2mp1hXcS59Y', null)
+      const res = await getMemberByAliasOrAddressRoute(app, USER_CHARLIE_TOKEN, null)
 
       expect(res.status).to.equal(200)
       expect(res.body).deep.equal(expectedResult)
@@ -270,17 +266,17 @@ describe('routes', function () {
       const { status, body } = await getSelfAddress(app, null)
       expect(status).to.equal(200)
       expect(body).to.deep.equal({
-        address: '5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty',
-        alias: null,
+        address: USER_BOB_TOKEN,
+        alias: USER_BOB_TOKEN,
       })
     })
 
     test('get self address with alias', async function () {
-      await putMemberAliasRoute(app, null, '5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty', { alias: 'TEST' })
+      await putMemberAliasRoute(app, null, USER_BOB_TOKEN, { alias: 'TEST' })
       const { status, body } = await getSelfAddress(app, null)
       expect(status).to.equal(200)
       expect(body).to.deep.equal({
-        address: '5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty',
+        address: USER_BOB_TOKEN,
         alias: 'TEST',
       })
     })


### PR DESCRIPTION
- For `/self` and `/members` if `alias: null` -> return `alias: {address}` instead
- `GET /members/{address}` still returns a member, even if there's no database alias, as long as the address is a member of the chain
- Return `400` if attempted to set alias of `PUT members/{address}` as an address