### PR TITLE
Remove old `check-version` from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -129,23 +129,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - Check version:
+      - name: Check version
         id: get_version
         uses: digicatapult/check-version@v1
         with:
-          token: ${{ secrets.GITHUB_TOKEN }
-      - run: git fetch --depth=1 --tags origin
-      - name: Install yq
-        run: sudo snap install yq
-      - name: Check Build Version
-        id: get_version
-        run: ./scripts/check-version.sh
-        shell: bash
-      - name: Skipping release as version has not increased
-        if: steps.get_version.outputs.IS_NEW_VERSION != 'true'
-        shell: bash
-        run: |
-          echo "Skipping release as current version has already been published"
+          token: ${{ secrets.GITHUB_TOKEN }}
 
   publish:
     name: 'Publish package'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/dscp-identity-service",
-  "version": "1.9.47",
+  "version": "1.9.48",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/dscp-identity-service",
-      "version": "1.9.47",
+      "version": "1.9.48",
       "license": "Apache-2.0",
       "dependencies": {
         "@polkadot/api": "^10.9.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/dscp-identity-service",
-  "version": "1.9.47",
+  "version": "1.9.48",
   "description": "Identity Service for DSCP",
   "type": "module",
   "main": "app/index.js",


### PR DESCRIPTION
Fixes the release workflow. Current behaviour: https://github.com/digicatapult/dscp-identity-service/actions/runs/6011088646
