### PR TITLE
Remove external origin envs

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,26 +39,24 @@ npx knex migrate:latest --env test
 
 `dscp-identity-service` is configured primarily using environment variables as follows:
 
-| variable             | required | default | description                                                                                                                   |
-| :------------------- | :------: | :-----: | :---------------------------------------------------------------------------------------------------------------------------- |
-| SERVICE_TYPE         |    N     | `info`  | Logging level. Valid values are [`trace`, `debug`, `info`, `warn`, `error`, `fatal`]                                          |
-| PORT                 |    N     | `3001`  | The port for the API to listen on                                                                                             |
-| EXTERNAL_ORIGIN      |    N     |         | The origin from which the OpenAPI service is accessible. If not provided the value will default to `http://localhost:${PORT}` |
-| EXTERNAL_PATH_PREFIX |    N     |         | A path prefix from which this service is served                                                                               |
-| LOG_LEVEL            |    N     | `info`  | Logging level. Valid values are [`trace`, `debug`, `info`, `warn`, `error`, `fatal`]                                          |
-| API_VERSION          |    N     |    -    | API version                                                                                                                   |
-| API_MAJOR_VERSION    |    N     |    -    | API major version                                                                                                             |
-| API_HOST             |    Y     |    -    | The hostname of the `dscp-node` the API should connect to                                                                |
-| API_PORT             |    N     | `9944`  | The port of the `dscp-node` the API should connect to                                                                    |
-| LOG_LEVEL            |    N     | `info`  | Logging level. Valid values are [`trace`, `debug`, `info`, `warn`, `error`, `fatal`]                                          |
-| USER_URI             |    Y     |    -    | The Substrate `URI` representing the private key to use when making `veritable-node` transactions                             |
-| DB_HOST              |    Y     |    -    | Hostname for the db                                                                                                           |
-| DB_PORT              |    N     |  5432   | Port to connect to the db                                                                                                     |
-| DB_NAME              |    N     | `dscp`  | Name of the database to connect to                                                                                            |
-| DB_USERNAME          |    Y     |    -    | Username to connect to the database with                                                                                      |
-| DB_PASSWORD          |    Y     |    -    | Password to connect to the database with                                                                                      |
-| SELF_ADDRESS         |    N     |    -    | Instance wallet address that is returned by `/self` endpoint                                                                  |
-| AUTH_TYPE            |    N     | `NONE`  | Authentication type for routes on the service. Valid values: [`NONE`, `JWT`, `EXTERNAL`]                                      |
+| variable          | required | default | description                                                                                       |
+| :---------------- | :------: | :-----: | :------------------------------------------------------------------------------------------------ |
+| SERVICE_TYPE      |    N     | `info`  | Logging level. Valid values are [`trace`, `debug`, `info`, `warn`, `error`, `fatal`]              |
+| PORT              |    N     | `3001`  | The port for the API to listen on                                                                 |
+| LOG_LEVEL         |    N     | `info`  | Logging level. Valid values are [`trace`, `debug`, `info`, `warn`, `error`, `fatal`]              |
+| API_VERSION       |    N     |    -    | API version                                                                                       |
+| API_MAJOR_VERSION |    N     |    -    | API major version                                                                                 |
+| API_HOST          |    Y     |    -    | The hostname of the `dscp-node` the API should connect to                                         |
+| API_PORT          |    N     | `9944`  | The port of the `dscp-node` the API should connect to                                             |
+| LOG_LEVEL         |    N     | `info`  | Logging level. Valid values are [`trace`, `debug`, `info`, `warn`, `error`, `fatal`]              |
+| USER_URI          |    Y     |    -    | The Substrate `URI` representing the private key to use when making `veritable-node` transactions |
+| DB_HOST           |    Y     |    -    | Hostname for the db                                                                               |
+| DB_PORT           |    N     |  5432   | Port to connect to the db                                                                         |
+| DB_NAME           |    N     | `dscp`  | Name of the database to connect to                                                                |
+| DB_USERNAME       |    Y     |    -    | Username to connect to the database with                                                          |
+| DB_PASSWORD       |    Y     |    -    | Password to connect to the database with                                                          |
+| SELF_ADDRESS      |    N     |    -    | Instance wallet address that is returned by `/self` endpoint                                      |
+| AUTH_TYPE         |    N     | `NONE`  | Authentication type for routes on the service. Valid values: [`NONE`, `JWT`, `EXTERNAL`]          |
 
 The following environment variables are additionally used when `AUTH_TYPE : 'JWT'`
 

--- a/app/api-v1/api-doc.js
+++ b/app/api-v1/api-doc.js
@@ -1,9 +1,6 @@
 import env from '../env.js'
 
-const { PORT, API_VERSION, API_MAJOR_VERSION, EXTERNAL_ORIGIN, EXTERNAL_PATH_PREFIX } = env
-
-let url = EXTERNAL_ORIGIN || `http://localhost:${PORT}`
-url = EXTERNAL_PATH_PREFIX ? `${url}/${EXTERNAL_PATH_PREFIX}` : url
+const { PORT, API_VERSION, API_MAJOR_VERSION } = env
 
 const apiDoc = {
   openapi: '3.0.3',
@@ -13,7 +10,7 @@ const apiDoc = {
   },
   servers: [
     {
-      url: `${url}/${API_MAJOR_VERSION}`,
+      url: `http://localhost:${PORT}/${API_MAJOR_VERSION}`,
     },
   ],
   components: {

--- a/app/env.js
+++ b/app/env.js
@@ -39,8 +39,6 @@ const vars = envalid.cleanEnv(
     DB_NAME: envalid.str({ default: 'dscp' }),
     DB_USERNAME: envalid.str({ devDefault: 'postgres' }),
     DB_PASSWORD: envalid.str({ devDefault: 'postgres' }),
-    EXTERNAL_ORIGIN: envalid.str({ default: '' }),
-    EXTERNAL_PATH_PREFIX: envalid.str({ default: '' }),
   },
   {
     strict: true,

--- a/app/server.js
+++ b/app/server.js
@@ -15,9 +15,7 @@ import { verifyJwks } from './util/authUtil.js'
 import promBundle from 'express-prom-bundle'
 import client from 'prom-client'
 
-const { EXTERNAL_ORIGIN, PORT, API_VERSION, API_MAJOR_VERSION, AUTH_TYPE, EXTERNAL_PATH_PREFIX } = env
-let URL = EXTERNAL_ORIGIN || `http://localhost:${PORT}`
-URL = EXTERNAL_PATH_PREFIX ? `${URL}/${EXTERNAL_PATH_PREFIX}/${API_MAJOR_VERSION}` : `${URL}/${API_MAJOR_VERSION}`
+const { PORT, API_VERSION, API_MAJOR_VERSION, AUTH_TYPE } = env
 
 import url from 'url'
 const __filename = url.fileURLToPath(import.meta.url)
@@ -76,7 +74,7 @@ export async function createHttpServer() {
     swaggerOptions: {
       urls: [
         {
-          url: `${URL}/api-docs`,
+          url: `${v1ApiDoc.servers[0].url}/api-docs`,
           name: 'IdentityService',
         },
       ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/dscp-identity-service",
-  "version": "1.9.48",
+  "version": "1.9.49",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/dscp-identity-service",
-      "version": "1.9.48",
+      "version": "1.9.49",
       "license": "Apache-2.0",
       "dependencies": {
         "@polkadot/api": "^10.9.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/dscp-identity-service",
-  "version": "1.9.48",
+  "version": "1.9.49",
   "description": "Identity Service for DSCP",
   "type": "module",
   "main": "app/index.js",


### PR DESCRIPTION
Remove `EXTERNAL_ORIGIN` and `EXTERNAL_PATH_PREFIX` as they never worked how we wanted them to serve multiple APIs specs on the same prefix (instead we merge specs with https://github.com/digicatapult/wasp-open-api)