### PR TITLE
Chore/upgrade chai to version 5

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@master
         with:
-          node-version: 18.x
+          node-version: 20.x
       - name: Use npm latest
         run: npm install -g npm@latest
       - name: Cache Node.js modules
@@ -66,7 +66,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@master
         with:
-          node-version: 18.x
+          node-version: 20.x
       - name: Use npm latest
         run: npm install -g npm@latest
       - name: Cache Node.js modules
@@ -92,7 +92,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@master
         with:
-          node-version: 18.x
+          node-version: 20.x
       - name: Use npm latest
         run: npm install -g npm@latest
       - name: Cache Node.js modules

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@master
         with:
-          node-version: 18.x
+          node-version: 20.x
       - name: Use npm latest
         run: npm install -g npm@latest
       - name: Cache Node.js modules
@@ -52,7 +52,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@master
         with:
-          node-version: 18.x
+          node-version: 20.x
       - name: Use npm latest
         run: npm install -g npm@latest
       - name: Cache Node.js modules
@@ -78,7 +78,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@master
         with:
-          node-version: 18.x
+          node-version: 20.x
       - name: Use npm latest
         run: npm install -g npm@latest
       - name: Cache Node.js modules

--- a/app/version.js
+++ b/app/version.js
@@ -1,3 +1,5 @@
-import packageJson from '../package.json' assert { type: 'json' }
-const { version } = packageJson
+import fs from 'fs'
+const packageJsonContent = fs.readFileSync('./package.json', 'utf-8')
+const { version } = JSON.parse(packageJsonContent)
+
 export default version

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -6,7 +6,6 @@ services:
     command:
       --base-path /data/
       --dev
-      --unsafe-ws-external
       --unsafe-rpc-external
       --rpc-cors all
     ports:

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,8 +47,8 @@
         "supertest": "^6.3.3"
       },
       "engines": {
-        "node": ">=18.x.x",
-        "npm": ">=9.x.x"
+        "node": "20.x.x",
+        "npm": "10.x.x"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/dscp-identity-service",
-  "version": "1.9.99",
+  "version": "1.9.100",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/dscp-identity-service",
-      "version": "1.9.99",
+      "version": "1.9.100",
       "license": "Apache-2.0",
       "dependencies": {
         "@polkadot/api": "^10.11.2",
@@ -32,7 +32,7 @@
         "@babel/eslint-parser": "^7.23.3",
         "@babel/plugin-syntax-import-assertions": "^7.23.3",
         "c8": "^8.0.1",
-        "chai": "^4.3.10",
+        "chai": "^5.0.0",
         "chai-json": "^1.0.0",
         "depcheck": "^1.4.7",
         "eslint": "^8.56.0",
@@ -2131,21 +2131,19 @@
       "peer": true
     },
     "node_modules/chai": {
-      "version": "4.3.10",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.10.tgz",
-      "integrity": "sha512-0UXG04VuVbruMUYbJ6JctvH0YnC/4q3/AkT18q4NaITo91CUm0liMS9VqzT9vZhVQ/1eqPanMWjBM+Juhfb/9g==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.0.0.tgz",
+      "integrity": "sha512-HO5p0oEKd5M6HEcwOkNAThAE3j960vIZvVcc0t2tI06Dd0ATu69cEnMB2wOhC5/ZyQ6m67w3ePjU/HzXsSsdBA==",
       "dev": true,
       "dependencies": {
-        "assertion-error": "^1.1.0",
-        "check-error": "^1.0.3",
-        "deep-eql": "^4.1.3",
-        "get-func-name": "^2.0.2",
-        "loupe": "^2.3.6",
-        "pathval": "^1.1.1",
-        "type-detect": "^4.0.8"
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.0.0",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.0.0",
+        "pathval": "^2.0.0"
       },
       "engines": {
-        "node": ">=4"
+        "node": ">=12"
       }
     },
     "node_modules/chai-json": {
@@ -2203,6 +2201,15 @@
         "node": "*"
       }
     },
+    "node_modules/chai/node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/chalk": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -2224,15 +2231,12 @@
       "dev": true
     },
     "node_modules/check-error": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.3.tgz",
-      "integrity": "sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.0.0.tgz",
+      "integrity": "sha512-tjLAOBHKVxtPoHe/SA7kNOMvhCRdCJ3vETdeY0RuAc9popf+hyaSV6ZEg9hr4cpWF7jmo/JSWEnLDrnijS9Tog==",
       "dev": true,
-      "dependencies": {
-        "get-func-name": "^2.0.2"
-      },
       "engines": {
-        "node": "*"
+        "node": ">= 16"
       }
     },
     "node_modules/chokidar": {
@@ -2572,13 +2576,10 @@
       }
     },
     "node_modules/deep-eql": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.3.tgz",
-      "integrity": "sha512-WaEtAOpRA1MQ0eohqZjpGD8zdI0Ovsm8mmFhaDN8dvDZzyoUMcYDnf5Y6iu7HTXxf8JDS23qWa4a+hKCDyOPzw==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.1.tgz",
+      "integrity": "sha512-nwQCf6ne2gez3o1MxWifqkciwt0zhl0LO1/UwVu4uMBuPmflWM4oQ70XMqHqnBJA+nhzncaqL9HVL6KkHJ28lw==",
       "dev": true,
-      "dependencies": {
-        "type-detect": "^4.0.0"
-      },
       "engines": {
         "node": ">=6"
       }
@@ -5159,12 +5160,12 @@
       }
     },
     "node_modules/loupe": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.6.tgz",
-      "integrity": "sha512-RaPMZKiMy8/JruncMU5Bt6na1eftNoo++R4Y+N2FrxkDVTrGvcyzFTsaGif4QTeKESheMGegbhw6iUAq+5A8zA==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.0.2.tgz",
+      "integrity": "sha512-Tzlkbynv7dtqxTROe54Il+J4e/zG2iehtJGZUYpTv8WzlkW9qyEcE83UhGJCeuF3SCfzHuM5VWhBi47phV3+AQ==",
       "dev": true,
       "dependencies": {
-        "get-func-name": "^2.0.0"
+        "get-func-name": "^2.0.1"
       }
     },
     "node_modules/lru-cache": {
@@ -6443,12 +6444,12 @@
       }
     },
     "node_modules/pathval": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
-      "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.0.tgz",
+      "integrity": "sha512-vE7JKRyES09KiunauX7nd2Q9/L7lhok4smP9RZTDeD4MVs72Dp2qNFVz39Nz5a0FVEW0BJR6C0DYrq6unoziZA==",
       "dev": true,
       "engines": {
-        "node": "*"
+        "node": ">= 14.16"
       }
     },
     "node_modules/pg": {
@@ -7906,15 +7907,6 @@
       },
       "engines": {
         "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/type-detect": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
-      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/type-fest": {
@@ -9889,18 +9881,24 @@
       "peer": true
     },
     "chai": {
-      "version": "4.3.10",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.10.tgz",
-      "integrity": "sha512-0UXG04VuVbruMUYbJ6JctvH0YnC/4q3/AkT18q4NaITo91CUm0liMS9VqzT9vZhVQ/1eqPanMWjBM+Juhfb/9g==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.0.0.tgz",
+      "integrity": "sha512-HO5p0oEKd5M6HEcwOkNAThAE3j960vIZvVcc0t2tI06Dd0ATu69cEnMB2wOhC5/ZyQ6m67w3ePjU/HzXsSsdBA==",
       "dev": true,
       "requires": {
-        "assertion-error": "^1.1.0",
-        "check-error": "^1.0.3",
-        "deep-eql": "^4.1.3",
-        "get-func-name": "^2.0.2",
-        "loupe": "^2.3.6",
-        "pathval": "^1.1.1",
-        "type-detect": "^4.0.8"
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.0.0",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.0.0",
+        "pathval": "^2.0.0"
+      },
+      "dependencies": {
+        "assertion-error": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+          "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+          "dev": true
+        }
       }
     },
     "chai-json": {
@@ -9968,13 +9966,10 @@
       "dev": true
     },
     "check-error": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.3.tgz",
-      "integrity": "sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==",
-      "dev": true,
-      "requires": {
-        "get-func-name": "^2.0.2"
-      }
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.0.0.tgz",
+      "integrity": "sha512-tjLAOBHKVxtPoHe/SA7kNOMvhCRdCJ3vETdeY0RuAc9popf+hyaSV6ZEg9hr4cpWF7jmo/JSWEnLDrnijS9Tog==",
+      "dev": true
     },
     "chokidar": {
       "version": "3.5.3",
@@ -10223,13 +10218,10 @@
       "dev": true
     },
     "deep-eql": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.3.tgz",
-      "integrity": "sha512-WaEtAOpRA1MQ0eohqZjpGD8zdI0Ovsm8mmFhaDN8dvDZzyoUMcYDnf5Y6iu7HTXxf8JDS23qWa4a+hKCDyOPzw==",
-      "dev": true,
-      "requires": {
-        "type-detect": "^4.0.0"
-      }
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.1.tgz",
+      "integrity": "sha512-nwQCf6ne2gez3o1MxWifqkciwt0zhl0LO1/UwVu4uMBuPmflWM4oQ70XMqHqnBJA+nhzncaqL9HVL6KkHJ28lw==",
+      "dev": true
     },
     "deep-is": {
       "version": "0.1.4",
@@ -12126,12 +12118,12 @@
       }
     },
     "loupe": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.6.tgz",
-      "integrity": "sha512-RaPMZKiMy8/JruncMU5Bt6na1eftNoo++R4Y+N2FrxkDVTrGvcyzFTsaGif4QTeKESheMGegbhw6iUAq+5A8zA==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.0.2.tgz",
+      "integrity": "sha512-Tzlkbynv7dtqxTROe54Il+J4e/zG2iehtJGZUYpTv8WzlkW9qyEcE83UhGJCeuF3SCfzHuM5VWhBi47phV3+AQ==",
       "dev": true,
       "requires": {
-        "get-func-name": "^2.0.0"
+        "get-func-name": "^2.0.1"
       }
     },
     "lru-cache": {
@@ -13083,9 +13075,9 @@
       "dev": true
     },
     "pathval": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
-      "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.0.tgz",
+      "integrity": "sha512-vE7JKRyES09KiunauX7nd2Q9/L7lhok4smP9RZTDeD4MVs72Dp2qNFVz39Nz5a0FVEW0BJR6C0DYrq6unoziZA==",
       "dev": true
     },
     "pg": {
@@ -14151,12 +14143,6 @@
       "requires": {
         "prelude-ls": "^1.2.1"
       }
-    },
-    "type-detect": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
-      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
-      "dev": true
     },
     "type-fest": {
       "version": "0.20.2",

--- a/package.json
+++ b/package.json
@@ -5,8 +5,10 @@
   "type": "module",
   "main": "app/index.js",
   "scripts": {
-    "test": "NODE_ENV=test mocha --config ./test/mocharc.cjs ./test",
-    "test:jwt": "NODE_ENV=test AUTH_TYPE=JWT mocha --config ./test/mocharc.cjs ./test",
+    "tes0": "NODE_ENV=test mocha --config ./test/mocharc.cjs ./test",
+    "test": "NODE_ENV=test mocha --config ./test/mocharc.json -r esm ./test",
+    "tes0:jwt": "NODE_ENV=test AUTH_TYPE=JWT mocha --config ./test/mocharc.cjs ./test",
+    "test:jwt": "NODE_ENV=test AUTH_TYPE=JWT mocha --config ./test/mocharc.json -r esm ./test",
     "lint": "eslint .",
     "depcheck": "depcheck",
     "start": "NODE_ENV=production node app/index.js",

--- a/package.json
+++ b/package.json
@@ -5,14 +5,14 @@
   "type": "module",
   "main": "app/index.js",
   "scripts": {
-    "test": "NODE_ENV=test NODE_OPTIONS='--experimental-json-modules' mocha --config ./test/mocharc.json -r esm ./test",
-    "test:jwt": "NODE_ENV=test NODE_OPTIONS='--experimental-json-modules' AUTH_TYPE=JWT mocha --config ./test/mocharc.json -r esm ./test",
+    "test": "NODE_ENV=test mocha --config ./test/mocharc.json -r esm ./test",
+    "test:jwt": "NODE_ENV=test AUTH_TYPE=JWT mocha --config ./test/mocharc.json -r esm ./test",
     "lint": "eslint .",
     "depcheck": "depcheck",
     "start": "NODE_ENV=production node app/index.js",
     "dev": "NODE_ENV=development nodemon app/index.js | pino-colada",
-    "coverage": "LOG_LEVEL=fatal NODE_OPTIONS='--experimental-json-modules' NODE_ENV=development c8 mocha --recursive ./test/integration -r esm --timeout 60000 --slow 20000 --exit",
-    "coverage:merge": "LOG_LEVEL=fatal NODE_OPTIONS='--experimental-json-modules' NODE_ENV=development c8 --no-clean npm run test && c8 --no-clean npm run test:jwt && c8 merge .c8_output --timeout 60000 --slow 20000 --exit"
+    "coverage": "LOG_LEVEL=fatal NODE_ENV=development c8 mocha --recursive ./test/integration -r esm --timeout 60000 --slow 20000 --exit",
+    "coverage:merge": "LOG_LEVEL=fatal NODE_ENV=development c8 --no-clean npm run test && c8 --no-clean npm run test:jwt && c8 merge .c8_output --timeout 60000 --slow 20000 --exit"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
     "url": "git+https://github.com/digicatapult/dscp-identity-service.git"
   },
   "engines": {
-    "node": ">=18.x.x",
-    "npm": ">=9.x.x"
+    "node": "20.x.x",
+    "npm": "10.x.x"
   },
   "keywords": [
     "DSCP"

--- a/package.json
+++ b/package.json
@@ -5,14 +5,14 @@
   "type": "module",
   "main": "app/index.js",
   "scripts": {
-    "test": "NODE_ENV=test mocha --config ./test/mocharc.json -r esm ./test",
-    "test:jwt": "NODE_ENV=test AUTH_TYPE=JWT mocha --config ./test/mocharc.json -r esm ./test",
+    "test": "NODE_ENV=test NODE_OPTIONS='--experimental-json-modules' mocha --config ./test/mocharc.json -r esm ./test",
+    "test:jwt": "NODE_ENV=test NODE_OPTIONS='--experimental-json-modules' AUTH_TYPE=JWT mocha --config ./test/mocharc.json -r esm ./test",
     "lint": "eslint .",
     "depcheck": "depcheck",
     "start": "NODE_ENV=production node app/index.js",
     "dev": "NODE_ENV=development nodemon app/index.js | pino-colada",
-    "coverage": "LOG_LEVEL=fatal NODE_ENV=development c8 mocha --recursive ./test/integration -r esm --timeout 60000 --slow 20000 --exit",
-    "coverage:merge": "LOG_LEVEL=fatal NODE_ENV=development c8 --no-clean npm run test && c8 --no-clean npm run test:jwt && c8 merge .c8_output --timeout 60000 --slow 20000 --exit"
+    "coverage": "LOG_LEVEL=fatal NODE_OPTIONS='--experimental-json-modules' NODE_ENV=development c8 mocha --recursive ./test/integration -r esm --timeout 60000 --slow 20000 --exit",
+    "coverage:merge": "LOG_LEVEL=fatal NODE_OPTIONS='--experimental-json-modules' NODE_ENV=development c8 --no-clean npm run test && c8 --no-clean npm run test:jwt && c8 merge .c8_output --timeout 60000 --slow 20000 --exit"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -5,15 +5,13 @@
   "type": "module",
   "main": "app/index.js",
   "scripts": {
-    "tes0": "NODE_ENV=test mocha --config ./test/mocharc.cjs ./test",
     "test": "NODE_ENV=test mocha --config ./test/mocharc.json -r esm ./test",
-    "tes0:jwt": "NODE_ENV=test AUTH_TYPE=JWT mocha --config ./test/mocharc.cjs ./test",
     "test:jwt": "NODE_ENV=test AUTH_TYPE=JWT mocha --config ./test/mocharc.json -r esm ./test",
     "lint": "eslint .",
     "depcheck": "depcheck",
     "start": "NODE_ENV=production node app/index.js",
     "dev": "NODE_ENV=development nodemon app/index.js | pino-colada",
-    "coverage": "LOG_LEVEL=fatal NODE_ENV=development c8 mocha --recursive ./test/integration --timeout 60000 --slow 20000 --exit",
+    "coverage": "LOG_LEVEL=fatal NODE_ENV=development c8 mocha --recursive ./test/integration -r esm --timeout 60000 --slow 20000 --exit",
     "coverage:merge": "LOG_LEVEL=fatal NODE_ENV=development c8 --no-clean npm run test && c8 --no-clean npm run test:jwt && c8 merge .c8_output --timeout 60000 --slow 20000 --exit"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/dscp-identity-service",
-  "version": "1.9.99",
+  "version": "1.9.100",
   "description": "Identity Service for DSCP",
   "type": "module",
   "main": "app/index.js",
@@ -55,7 +55,7 @@
     "@babel/eslint-parser": "^7.23.3",
     "@babel/plugin-syntax-import-assertions": "^7.23.3",
     "c8": "^8.0.1",
-    "chai": "^4.3.10",
+    "chai": "^5.0.0",
     "chai-json": "^1.0.0",
     "depcheck": "^1.4.7",
     "eslint": "^8.56.0",

--- a/test/integration/docs.test.js
+++ b/test/integration/docs.test.js
@@ -1,8 +1,10 @@
 import { describe, before, it } from 'mocha'
 import jsonChai from 'chai-json'
-import chai from 'chai'
+// import chai from 'chai'
+import { expect, use } from 'chai'
 
-const { expect } = chai.use(jsonChai)
+// const { expect } = chai.use(jsonChai)
+use(jsonChai)  // Make sure to use chai-json plugin
 
 import { createHttpServer } from '../../app/server.js'
 import { apiDocs } from '../helper/routeHelper.js'

--- a/test/integration/docs.test.js
+++ b/test/integration/docs.test.js
@@ -1,9 +1,7 @@
 import { describe, before, it } from 'mocha'
 import jsonChai from 'chai-json'
-// import chai from 'chai'
 import { expect, use } from 'chai'
 
-// const { expect } = chai.use(jsonChai)
 use(jsonChai) // Make sure to use chai-json plugin
 
 import { createHttpServer } from '../../app/server.js'

--- a/test/integration/docs.test.js
+++ b/test/integration/docs.test.js
@@ -4,7 +4,7 @@ import jsonChai from 'chai-json'
 import { expect, use } from 'chai'
 
 // const { expect } = chai.use(jsonChai)
-use(jsonChai)  // Make sure to use chai-json plugin
+use(jsonChai) // Make sure to use chai-json plugin
 
 import { createHttpServer } from '../../app/server.js'
 import { apiDocs } from '../helper/routeHelper.js'

--- a/test/mocharc.cjs
+++ b/test/mocharc.cjs
@@ -1,7 +1,0 @@
-module.exports = {
-  recursive: true,
-  slow: 500,
-  timeout: 1000,
-  extension: ['.test.js'],
-  exit: true,
-}

--- a/test/mocharc.json
+++ b/test/mocharc.json
@@ -1,0 +1,7 @@
+{
+  "recursive": true,
+  "slow": 500,
+  "timeout": 1000,
+  "extension": [".test.js"],
+  "exit": true
+}


### PR DESCRIPTION
---
name: Upgrade to chai 5
about: Fixes the issues that are preventing the chai 5 auto upgrade
---

## Summary

**[Chai 5](https://github.com/chaijs/chai)** upgrade.

## Motivation

The code needs to be up-to-date w/ all the new major lib upgrades.

## Describe alternatives you've considered

Upgrade chai to v5.

Note: That this PR superseds #176 .

## Additional context

Currently , Renovate in PR #176 is trying without success to upgrade chai to v5 .. both normal test and JWT tests are failing and the current log is showing some warning messages as well (especially the ones about experimental features):

```
(node:2595) ExperimentalWarning: Importing JSON modules is an experimental feature and might change at any time
(Use `node --trace-warnings ...` to show where the warning was created)

file:///home/runner/work/dscp-identity-service/dscp-identity-service/test/integration/docs.test.js:3
import chai from 'chai'
       ^^^^
SyntaxError: The requested module 'chai' does not provide an export named 'default'
    at ModuleJob._instantiate (node:internal/modules/esm/module_job:[12](https://github.com/digicatapult/dscp-identity-service/actions/runs/7395696278/job/20119356231?pr=176#step:11:13)3:21)
    at async ModuleJob.run (node:internal/modules/esm/module_job:191:5)
    at async ModuleLoader.import (node:internal/modules/esm/loader:336:24)
    at async importModuleDynamicallyWrapper (node:internal/vm/module:429:15)
    at async formattedImport (/home/runner/work/dscp-identity-service/dscp-identity-service/node_modules/mocha/lib/nodejs/esm-utils.js:9:[14](https://github.com/digicatapult/dscp-identity-service/actions/runs/7395696278/job/20119356231?pr=176#step:11:15))
    at async exports.requireOrImport (/home/runner/work/dscp-identity-service/dscp-identity-service/node_modules/mocha/lib/nodejs/esm-utils.js:42:28)
    at async exports.loadFilesAsync (/home/runner/work/dscp-identity-service/dscp-identity-service/node_modules/mocha/lib/nodejs/esm-utils.js:100:[20](https://github.com/digicatapult/dscp-identity-service/actions/runs/7395696278/job/20119356231?pr=176#step:11:21))
    at async singleRun (/home/runner/work/dscp-identity-service/dscp-identity-service/node_modules/mocha/lib/cli/run-helpers.js:125:3)
    at async exports.handler (/home/runner/work/dscp-identity-service/dscp-identity-service/node_modules/mocha/lib/cli/run.js:370:5)
```

This includes:

* A change that allows the import with destructuring assignment plus it adds a simplified way of adding the chai-hson plugin
* The conversion from **mocharc.cjs** to mocharc.json ( another option would have been to convert it to mjs but one could argue that JSON is better when it comes )
* A small change to the **docker-compose.yaml** file to make sure the main script is compatible with the new DSCP node
* The insertion of `-r esm` in every npm run script
* The switch to Node 20 engine
* A new app/version.js that uses fs.read ( file.json ) instead of import file.json to suppress the warning messages ( another option would have been to add **`NODE_OPTIONS='--experimental-json-modules'`** this way it is easier to type short commands in the terminal without worrying about anything and adding extra flags.

<!-- Add any other context or screenshots about the feature request here. -->

---
